### PR TITLE
Overhaul portfolio + auto-deploy to GitHub Pages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "jevgeni-portfolio",
       "dependencies": {
+        "@react-pdf/renderer": "^4.5.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },
@@ -17,6 +18,40 @@
     },
   },
   "packages": {
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@react-pdf/fns": ["@react-pdf/fns@3.1.3", "", {}, "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w=="],
+
+    "@react-pdf/font": ["@react-pdf/font@4.0.8", "", { "dependencies": { "@react-pdf/pdfkit": "^5.1.1", "@react-pdf/types": "^2.11.1", "fontkit": "^2.0.2", "is-url": "^1.2.4" } }, "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA=="],
+
+    "@react-pdf/image": ["@react-pdf/image@3.1.0", "", { "dependencies": { "@react-pdf/svg": "^1.1.0", "jay-peg": "^1.1.1", "png-js": "^2.0.0" } }, "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g=="],
+
+    "@react-pdf/layout": ["@react-pdf/layout@4.6.1", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "@react-pdf/image": "^3.1.0", "@react-pdf/primitives": "^4.3.0", "@react-pdf/stylesheet": "^6.2.1", "@react-pdf/textkit": "^6.3.0", "@react-pdf/types": "^2.11.1", "emoji-regex-xs": "^1.0.0", "queue": "^6.0.1", "yoga-layout": "^3.2.1" } }, "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA=="],
+
+    "@react-pdf/pdfkit": ["@react-pdf/pdfkit@5.1.1", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@noble/ciphers": "^1.0.0", "@noble/hashes": "^1.6.0", "browserify-zlib": "^0.2.0", "fontkit": "^2.0.2", "jay-peg": "^1.1.1", "js-md5": "^0.8.3", "linebreak": "^1.1.0", "png-js": "^2.0.0", "vite-compatible-readable-stream": "^3.6.1" } }, "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg=="],
+
+    "@react-pdf/primitives": ["@react-pdf/primitives@4.3.0", "", {}, "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A=="],
+
+    "@react-pdf/reconciler": ["@react-pdf/reconciler@2.0.0", "", { "dependencies": { "object-assign": "^4.1.1", "scheduler": "0.25.0-rc-603e6108-20241029" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw=="],
+
+    "@react-pdf/render": ["@react-pdf/render@4.5.1", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@react-pdf/fns": "3.1.3", "@react-pdf/primitives": "^4.3.0", "@react-pdf/textkit": "^6.3.0", "@react-pdf/types": "^2.11.1", "abs-svg-path": "^0.1.1", "color-string": "^2.1.4", "normalize-svg-path": "^1.1.0", "parse-svg-path": "^0.1.2", "svg-arc-to-cubic-bezier": "^3.2.0" } }, "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA=="],
+
+    "@react-pdf/renderer": ["@react-pdf/renderer@4.5.1", "", { "dependencies": { "@babel/runtime": "^7.20.13", "@react-pdf/fns": "3.1.3", "@react-pdf/font": "^4.0.8", "@react-pdf/layout": "^4.6.1", "@react-pdf/pdfkit": "^5.1.1", "@react-pdf/primitives": "^4.3.0", "@react-pdf/reconciler": "^2.0.0", "@react-pdf/render": "^4.5.1", "@react-pdf/types": "^2.11.1", "events": "^3.3.0", "object-assign": "^4.1.1", "prop-types": "^15.6.2", "queue": "^6.0.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q=="],
+
+    "@react-pdf/stylesheet": ["@react-pdf/stylesheet@6.2.1", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "@react-pdf/types": "^2.11.1", "color-string": "^2.1.4", "hsl-to-hex": "^1.0.0", "media-engine": "^1.0.3", "postcss-value-parser": "^4.1.0" } }, "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A=="],
+
+    "@react-pdf/svg": ["@react-pdf/svg@1.1.0", "", { "dependencies": { "@react-pdf/primitives": "^4.3.0" } }, "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA=="],
+
+    "@react-pdf/textkit": ["@react-pdf/textkit@6.3.0", "", { "dependencies": { "@react-pdf/fns": "3.1.3", "bidi-js": "^1.0.2", "hyphen": "^1.6.4", "unicode-properties": "^1.4.1" } }, "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ=="],
+
+    "@react-pdf/types": ["@react-pdf/types@2.11.1", "", { "dependencies": { "@react-pdf/font": "^4.0.8", "@react-pdf/primitives": "^4.3.0", "@react-pdf/stylesheet": "^6.2.1" } }, "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw=="],
+
+    "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
@@ -25,18 +60,118 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "abs-svg-path": ["abs-svg-path@0.1.1", "", {}, "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="],
+
+    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
+
+    "browserify-zlib": ["browserify-zlib@0.2.0", "", { "dependencies": { "pako": "~1.0.5" } }, "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
+
+    "color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
+
+    "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "dfa": ["dfa@1.2.0", "", {}, "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="],
+
+    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
+    "fontkit": ["fontkit@2.0.4", "", { "dependencies": { "@swc/helpers": "^0.5.12", "brotli": "^1.3.2", "clone": "^2.1.2", "dfa": "^1.2.0", "fast-deep-equal": "^3.1.3", "restructure": "^3.0.0", "tiny-inflate": "^1.0.3", "unicode-properties": "^1.4.0", "unicode-trie": "^2.0.0" } }, "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g=="],
+
+    "hsl-to-hex": ["hsl-to-hex@1.0.0", "", { "dependencies": { "hsl-to-rgb-for-reals": "^1.1.0" } }, "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA=="],
+
+    "hsl-to-rgb-for-reals": ["hsl-to-rgb-for-reals@1.1.1", "", {}, "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg=="],
+
+    "hyphen": ["hyphen@1.14.1", "", {}, "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is-url": ["is-url@1.2.4", "", {}, "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="],
+
+    "jay-peg": ["jay-peg@1.1.1", "", { "dependencies": { "restructure": "^3.0.0" } }, "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww=="],
+
+    "js-md5": ["js-md5@0.8.3", "", {}, "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "media-engine": ["media-engine@1.0.3", "", {}, "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg=="],
+
+    "normalize-svg-path": ["normalize-svg-path@1.1.0", "", { "dependencies": { "svg-arc-to-cubic-bezier": "^3.0.0" } }, "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parse-svg-path": ["parse-svg-path@0.1.2", "", {}, "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="],
+
+    "png-js": ["png-js@2.0.0", "", { "dependencies": { "fflate": "^0.8.2" } }, "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "restructure": ["restructure@3.0.2", "", {}, "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "svg-arc-to-cubic-bezier": ["svg-arc-to-cubic-bezier@3.2.0", "", {}, "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="],
+
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "unicode-properties": ["unicode-properties@1.4.1", "", { "dependencies": { "base64-js": "^1.3.0", "unicode-trie": "^2.0.0" } }, "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vite-compatible-readable-stream": ["vite-compatible-readable-stream@3.6.1", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "@react-pdf/reconciler/scheduler": ["scheduler@0.25.0-rc-603e6108-20241029", "", {}, "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA=="],
+
+    "brotli/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "unicode-properties/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
   }
 }

--- a/index.html
+++ b/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jevgeni Rumjantsev — Senior Software Engineer · Payments &amp; Fintech</title>
+    <title>Jevgeni Rumjantsev — Software Engineer · Payments &amp; Crypto</title>
     <meta
       name="description"
-      content="Jevgeni Rumjantsev — Senior Software Engineer with 12+ years building scalable, fault-tolerant payments backends. Node.js & Rust. AI-augmented delivery with Claude Code."
+      content="Jevgeni Rumjantsev — Software Engineer with 13+ years building scalable, fault-tolerant systems across crypto, payments, GovTech and SaaS. Node.js, Rust, .NET. AI-augmented delivery."
     />
     <meta name="author" content="Jevgeni Rumjantsev" />
     <meta name="theme-color" content="#0e0f11" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Jevgeni Rumjantsev — Senior Software Engineer" />
+    <meta property="og:title" content="Jevgeni Rumjantsev — Software Engineer" />
     <meta
       property="og:description"
-      content="Payments & Fintech specialist. Node.js & Rust. AI-augmented delivery."
+      content="Payments, crypto & distributed systems. Node.js, Rust, .NET. AI-augmented delivery."
     />
     <meta property="og:url" content="https://jackinf.github.io" />
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "bun run scripts/serve.ts"
   },
   "dependencies": {
+    "@react-pdf/renderer": "^4.5.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -22,6 +22,9 @@ const result = await Bun.build({
   entrypoints: [`${root}index.html`],
   outdir: dist,
   minify: true,
+  // Code-split so the heavy PDF renderer (@react-pdf/renderer) lands in its
+  // own chunk and is fetched only when "Download CV" is clicked.
+  splitting: true,
   sourcemap: "linked",
   naming: {
     entry: "[dir]/[name].[ext]",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,30 @@
+import { useState } from "react";
 import { Nav } from "./components/Nav.tsx";
 import { Hero } from "./components/Hero.tsx";
 import { Experience } from "./components/Experience.tsx";
+import { LanguageTimeline } from "./components/LanguageTimeline.tsx";
 import { Projects } from "./components/Projects.tsx";
 import { Skills } from "./components/Skills.tsx";
 import { Education } from "./components/Education.tsx";
 import { Footer } from "./components/Footer.tsx";
+import { AnimatedBackground } from "./components/AnimatedBackground.tsx";
+import { ScrollMinimap } from "./components/ScrollMinimap.tsx";
 import { useTheme } from "./hooks/useTheme.ts";
+import type { DomainId } from "./data/cv.ts";
 
 export function App() {
   const { theme, toggle } = useTheme();
+  const [domain, setDomain] = useState<DomainId>("all");
 
   return (
     <>
+      <AnimatedBackground />
       <Nav theme={theme} onToggleTheme={toggle} />
+      <ScrollMinimap />
       <main>
-        <Hero />
-        <Experience />
+        <Hero domain={domain} onDomainChange={setDomain} />
+        <Experience domain={domain} />
+        <LanguageTimeline />
         <Projects />
         <Skills />
         <Education />

--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -1,0 +1,26 @@
+import { useActiveSection } from "../hooks/useActiveSection.ts";
+
+const SECTIONS = [
+  "top",
+  "experience",
+  "languages",
+  "projects",
+  "skills",
+  "education",
+];
+
+/**
+ * Fixed, section-aware background that shifts colour + pattern as you move
+ * between panels. Pure CSS transitions — see global.css `.bg[data-section]`.
+ */
+export function AnimatedBackground() {
+  const active = useActiveSection(SECTIONS, "top");
+  return (
+    <div className="bg" data-section={active} aria-hidden="true">
+      <span className="bg__layer bg__layer--gradient" />
+      <span className="bg__layer bg__layer--pattern" />
+      <span className="bg__layer bg__layer--blob bg__layer--blob-a" />
+      <span className="bg__layer bg__layer--blob bg__layer--blob-b" />
+    </div>
+  );
+}

--- a/src/components/DomainSpinner.tsx
+++ b/src/components/DomainSpinner.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState, type CSSProperties, type WheelEvent } from "react";
+import { domains, type DomainId } from "../data/cv.ts";
+
+interface Props {
+  value: DomainId;
+  onChange: (id: DomainId) => void;
+}
+
+/** Degrees between items on the cylindrical picker wheel. */
+const STEP = 30;
+
+/**
+ * A 3-D cylindrical picker wheel ("spinner") for choosing a domain. The
+ * selected domain re-frames the headline shown beside it. Fully keyboard- and
+ * pointer-operable; falls back to a flat list under prefers-reduced-motion.
+ */
+export function DomainSpinner({ value, onChange }: Props) {
+  const index = Math.max(0, domains.findIndex((d) => d.id === value));
+  const active = domains[index];
+  const [reduce, setReduce] = useState(false);
+  const wheelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduce(mq.matches);
+    const fn = () => setReduce(mq.matches);
+    mq.addEventListener("change", fn);
+    return () => mq.removeEventListener("change", fn);
+  }, []);
+
+  const step = (dir: number) => {
+    const next = (index + dir + domains.length) % domains.length;
+    onChange(domains[next].id);
+  };
+
+  // Wheel scroll / drag handling.
+  const onWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    step(e.deltaY > 0 ? 1 : -1);
+  };
+
+  return (
+    <div
+      className="spinner"
+      style={{ "--domain-color": active.color } as CSSProperties}
+    >
+      <div className="spinner__picker" role="listbox" aria-label="Filter by domain">
+        <button
+          type="button"
+          className="spinner__arrow"
+          aria-label="Previous domain"
+          onClick={() => step(-1)}
+        >
+          ▲
+        </button>
+
+        <div
+          className={`spinner__stage${reduce ? " is-flat" : ""}`}
+          tabIndex={0}
+          ref={wheelRef}
+          onWheel={reduce ? undefined : onWheel}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+              e.preventDefault();
+              step(-1);
+            } else if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+              e.preventDefault();
+              step(1);
+            }
+          }}
+        >
+          <div
+            className="spinner__wheel"
+            style={
+              reduce
+                ? undefined
+                : ({ transform: `translateZ(-92px) rotateX(${index * STEP}deg)` } as CSSProperties)
+            }
+          >
+            {domains.map((d, i) => {
+              const selected = i === index;
+              return (
+                <button
+                  type="button"
+                  key={d.id}
+                  role="option"
+                  aria-selected={selected}
+                  className={`spinner__item${selected ? " is-selected" : ""}`}
+                  style={
+                    reduce
+                      ? undefined
+                      : ({
+                          transform: `rotateX(${-i * STEP}deg) translateZ(92px)`,
+                          "--c": d.color,
+                        } as CSSProperties)
+                  }
+                  onClick={() => onChange(d.id)}
+                >
+                  <span className="spinner__icon" aria-hidden="true">
+                    {d.icon}
+                  </span>
+                  <span className="spinner__label">{d.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          <span className="spinner__mask spinner__mask--top" aria-hidden="true" />
+          <span className="spinner__mask spinner__mask--bottom" aria-hidden="true" />
+        </div>
+
+        <button
+          type="button"
+          className="spinner__arrow"
+          aria-label="Next domain"
+          onClick={() => step(1)}
+        >
+          ▼
+        </button>
+      </div>
+      <p className="spinner__hint">Spin to re-frame ↻</p>
+    </div>
+  );
+}

--- a/src/components/DownloadCV.tsx
+++ b/src/components/DownloadCV.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+/**
+ * Generates a polished, deterministic PDF on the client via @react-pdf/renderer
+ * (lazy-loaded) and downloads it. No Chrome "Print to PDF".
+ */
+export function DownloadCV() {
+  const [state, setState] = useState<"idle" | "working" | "error">("idle");
+
+  const onClick = async () => {
+    if (state === "working") return;
+    setState("working");
+    try {
+      const { buildCvBlob } = await import("../cv/CvDocument.tsx");
+      const blob = await buildCvBlob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "Jevgeni_Rumjantsev_CV.pdf";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 4000);
+      setState("idle");
+    } catch (err) {
+      console.error("CV generation failed", err);
+      setState("error");
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="btn btn--primary"
+      onClick={onClick}
+      disabled={state === "working"}
+    >
+      {state === "working"
+        ? "Building PDF…"
+        : state === "error"
+          ? "Retry download"
+          : "Download CV"}
+    </button>
+  );
+}

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,22 +1,62 @@
-import { education } from "../data/cv.ts";
 import { Reveal } from "./Reveal.tsx";
+import { education, certifications, humanLanguages } from "../data/cv.ts";
 
 export function Education() {
   return (
-    <section className="section" id="education">
-      <div className="container">
-        <Reveal className="section__head">
-          <span className="section__num">04</span>
-          <h2 className="section__title">Education</h2>
+    <section className="section section--tight" id="education">
+      <div className="section__head">
+        <Reveal as="h2" className="section__title">
+          Education &amp; certifications
+        </Reveal>
+      </div>
+
+      <div className="edu">
+        {education.map((e, i) => (
+          <Reveal className="edu__item" key={e.degree} delay={i * 60}>
+            <h3 className="edu__degree">{e.degree}</h3>
+            <span className="edu__school">{e.school}</span>
+            <span className="edu__period">
+              {e.period}
+              {e.note ? ` · ${e.note}` : ""}
+            </span>
+          </Reveal>
+        ))}
+      </div>
+
+      <div className="creds">
+        <Reveal className="creds__col">
+          <h3 className="creds__title">Certifications</h3>
+          <ul className="creds__list">
+            {certifications.map((c) => (
+              <li key={c.name} className="cert">
+                <span className="cert__name">{c.name}</span>
+                <span className="cert__issuer">
+                  {c.issuer}
+                  {c.year ? ` · ${c.year}` : ""}
+                </span>
+              </li>
+            ))}
+          </ul>
         </Reveal>
 
-        <Reveal className="education">
-          {education.map((e) => (
-            <div className="edu" key={e.degree}>
-              <span className="edu__degree">{e.degree}</span>
-              <span className="edu__period">{e.period}</span>
-            </div>
-          ))}
+        <Reveal className="creds__col" delay={80}>
+          <h3 className="creds__title">Spoken languages</h3>
+          <ul className="creds__list creds__list--langs">
+            {humanLanguages.map((l) => (
+              <li key={l.language} className="hlang">
+                <div className="hlang__top">
+                  <span className="hlang__name">{l.language}</span>
+                  <span className="hlang__level">{l.level}</span>
+                </div>
+                <div className="hlang__bar">
+                  <span
+                    className="hlang__fill"
+                    style={{ width: `${l.proficiency}%` }}
+                  />
+                </div>
+              </li>
+            ))}
+          </ul>
         </Reveal>
       </div>
     </section>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,65 +1,68 @@
-import { earlier, experience } from "../data/cv.ts";
 import { Reveal } from "./Reveal.tsx";
+import { experience, type DomainId } from "../data/cv.ts";
+import { highlightNumbers } from "../lib/highlight.tsx";
 
-export function Experience() {
+interface ExperienceProps {
+  domain: DomainId;
+}
+
+export function Experience({ domain }: ExperienceProps) {
+  const filtering = domain !== "all";
+
   return (
     <section className="section" id="experience">
-      <div className="container">
-        <Reveal className="section__head">
-          <span className="section__num">01</span>
-          <h2 className="section__title">Experience</h2>
+      <div className="section__head">
+        <Reveal as="h2" className="section__title">
+          Experience
         </Reveal>
-
-        <div className="timeline">
-          {experience.map((role, i) => (
+        <Reveal as="p" className="section__sub">
+          The full, unredacted history — from ABB in 2012 to crypto payments today,
+          across {experience.length} roles and eight industries.
+        </Reveal>
+      </div>
+      <div className="exp">
+        {experience.map((role, i) => {
+          const matches = filtering && role.domains.includes(domain);
+          const dimmed = filtering && !matches;
+          return (
             <Reveal
+              className={`exp__item${role.current ? " exp__item--current" : ""}${
+                matches ? " exp__item--match" : ""
+              }${dimmed ? " exp__item--dim" : ""}`}
               key={role.company}
-              as="article"
-              className={`role${role.current ? " role--current" : ""}`}
               delay={i * 60}
             >
-              <div className="role__head">
-                <h3 className="role__company">
-                  {role.company}
-                  {role.current && <span className="tag-current">Current</span>}
-                </h3>
-                <span className="role__period">{role.period}</span>
+              <div className="exp__head">
+                <div>
+                  <h3 className="exp__company">
+                    {role.company}
+                    {role.companyNote && (
+                      <span className="exp__note"> · {role.companyNote}</span>
+                    )}
+                    {role.current && <span className="exp__badge">Current</span>}
+                  </h3>
+                  <p className="exp__role">{role.role}</p>
+                </div>
+                <div className="exp__meta">
+                  <span className="exp__period">{role.period}</span>
+                  <span className="exp__location">{role.location}</span>
+                </div>
               </div>
-              <div className="role__sub">
-                <span className="role__role">{role.role}</span>
-                {role.companyNote && <span>· {role.companyNote}</span>}
-                <span>· {role.location}</span>
-              </div>
-
-              <ul className="role__list">
+              <ul className="exp__highlights">
                 {role.highlights.map((h) => (
-                  <li key={h}>{h}</li>
+                  <li key={h}>{highlightNumbers(h)}</li>
                 ))}
               </ul>
-
               {role.stack && (
-                <div className="tags">
+                <ul className="exp__stack">
                   {role.stack.map((t) => (
-                    <span className="tag" key={t}>{t}</span>
+                    <li key={t}>{t}</li>
                   ))}
-                </div>
+                </ul>
               )}
             </Reveal>
-          ))}
-        </div>
-
-        <Reveal className="earlier">
-          {earlier.map((e) => (
-            <div className="earlier__item" key={e.company}>
-              <div className="earlier__top">
-                <span className="earlier__company">{e.company}</span>
-                <span className="earlier__period">{e.period}</span>
-              </div>
-              <div className="earlier__role">{e.role}</div>
-              <p className="earlier__summary">{e.summary}</p>
-            </div>
-          ))}
-        </Reveal>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/components/ExperienceCounter.tsx
+++ b/src/components/ExperienceCounter.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { CAREER_START } from "../data/cv.ts";
+
+function diff(from: Date, to: Date) {
+  let years = to.getFullYear() - from.getFullYear();
+  let months = to.getMonth() - from.getMonth();
+  let days = to.getDate() - from.getDate();
+  if (days < 0) {
+    months -= 1;
+    days += new Date(to.getFullYear(), to.getMonth(), 0).getDate();
+  }
+  if (months < 0) {
+    years -= 1;
+    months += 12;
+  }
+  const decimal = (to.getTime() - from.getTime()) / (365.25 * 24 * 3600 * 1000);
+  return { years, months, days, decimal };
+}
+
+/**
+ * A styled, self-updating "years of experience" panel, dynamically calculated
+ * from the first day of work (20 Jun 2012).
+ */
+export function ExperienceCounter() {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const { years, months, days, decimal } = diff(CAREER_START, now);
+
+  return (
+    <div className="stat stat--counter reveal is-visible">
+      <span className="stat__value">{years}+</span>
+      <span className="stat__label">Years engineering</span>
+      <span className="stat__ticker" title="Since 20 June 2012">
+        {years}y · {months}m · {days}d &nbsp;
+        <span className="stat__decimal">({decimal.toFixed(6)})</span>
+      </span>
+    </div>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,63 +1,89 @@
-import { profile, stats } from "../data/cv.ts";
-import {
-  DownloadIcon,
-  GitHubIcon,
-  LinkedInIcon,
-  MailIcon,
-  PhoneIcon,
-  PinIcon,
-} from "./icons.tsx";
+import { Reveal } from "./Reveal.tsx";
+import { DomainSpinner } from "./DomainSpinner.tsx";
+import { ExperienceCounter } from "./ExperienceCounter.tsx";
+import { DownloadCV } from "./DownloadCV.tsx";
+import { profile, domains, type DomainId } from "../data/cv.ts";
+import { GitHubIcon, LinkedInIcon, MailIcon } from "./icons.tsx";
 
-export function Hero() {
+interface HeroProps {
+  domain: DomainId;
+  onDomainChange: (id: DomainId) => void;
+}
+
+export function Hero({ domain, onDomainChange }: HeroProps) {
+  const active = domains.find((d) => d.id === domain) ?? domains[0];
+  const description = domain === "all" ? profile.summary : active.blurb;
+
   return (
-    <section className="hero" id="top">
-      <div className="container">
-        <p className="hero__eyebrow">
-          <span className="hero__dot" aria-hidden="true" />
-          Open to senior / staff payments &amp; backend roles
-        </p>
+    <header className="hero" id="top">
+      <div className="hero__grid">
+        <div className="hero__inner">
+          <Reveal as="p" className="hero__eyebrow">
+            {profile.location}
+          </Reveal>
+          <Reveal as="h1" className="hero__name" delay={60}>
+            {profile.name}
+          </Reveal>
+          <Reveal as="p" className="hero__title" delay={120}>
+            {profile.title}
+          </Reveal>
+          <Reveal as="p" className="hero__tagline" delay={180}>
+            {profile.tagline}
+          </Reveal>
 
-        <h1 className="hero__name">{profile.name}</h1>
-        <p className="hero__title">
-          {profile.title} · <em>{profile.tagline}</em>
-        </p>
+          <Reveal className="hero__lead" delay={220}>
+            <p className="hero__summary" key={domain}>
+              {description}
+            </p>
+          </Reveal>
 
-        <p className="hero__summary">{profile.summary}</p>
-
-        <div className="contacts">
-          <span>
-            <PinIcon /> {profile.location}
-          </span>
-          <a href={profile.phoneHref}>
-            <PhoneIcon /> {profile.phone}
-          </a>
-          <a href={`mailto:${profile.email}`}>
-            <MailIcon /> {profile.email}
-          </a>
-          <a href={profile.linkedinUrl} target="_blank" rel="noreferrer">
-            <LinkedInIcon /> {profile.linkedin}
-          </a>
-          <a href={profile.githubUrl} target="_blank" rel="noreferrer">
-            <GitHubIcon /> {profile.github}
-          </a>
+          <Reveal className="hero__contact" delay={260}>
+            <a className="hero__link" href={profile.linkedinUrl} target="_blank" rel="noreferrer">
+              <LinkedInIcon /> LinkedIn
+            </a>
+            <a className="hero__link" href={profile.githubUrl} target="_blank" rel="noreferrer">
+              <GitHubIcon /> GitHub
+            </a>
+            <a className="hero__link" href={`mailto:${profile.email}`}>
+              <MailIcon /> Email
+            </a>
+          </Reveal>
+          <Reveal className="hero__cta" delay={300}>
+            <DownloadCV />
+            <a className="btn btn--ghost" href="#experience">
+              View experience
+            </a>
+          </Reveal>
         </div>
 
-        <div className="hero__actions">
-          <button type="button" className="btn btn--primary" onClick={() => window.print()}>
-            <DownloadIcon /> Download CV
-          </button>
-          <a className="btn" href="#experience">View experience</a>
-        </div>
-
-        <dl className="stats">
-          {stats.map((s) => (
-            <div className="stat" key={s.label}>
-              <dt className="stat__value">{s.value}</dt>
-              <dd className="stat__label">{s.label}</dd>
-            </div>
-          ))}
-        </dl>
+        <Reveal className="hero__aside" delay={200}>
+          <DomainSpinner value={domain} onChange={onDomainChange} />
+        </Reveal>
       </div>
-    </section>
+
+      <div className="hero__stats">
+        <ExperienceCounter />
+        <Reveal className="stat" delay={60}>
+          <span className="stat__value">8</span>
+          <span className="stat__label">Industries shipped in</span>
+        </Reveal>
+        <Reveal className="stat" delay={120}>
+          <span className="stat__value">5+</span>
+          <span className="stat__label">Production languages</span>
+        </Reveal>
+        <Reveal className="stat" delay={180}>
+          <span className="stat__value">€100Ks+</span>
+          <span className="stat__label">Conversion lifted in payments</span>
+        </Reveal>
+        <Reveal className="stat" delay={240}>
+          <span className="stat__value">Node · Rust</span>
+          <span className="stat__label">Daily drivers today</span>
+        </Reveal>
+        <Reveal className="stat" delay={300}>
+          <span className="stat__value">AI-augmented</span>
+          <span className="stat__label">Agent-assisted delivery</span>
+        </Reveal>
+      </div>
+    </header>
   );
 }

--- a/src/components/LanguageTimeline.tsx
+++ b/src/components/LanguageTimeline.tsx
@@ -1,0 +1,74 @@
+import { Reveal } from "./Reveal.tsx";
+import {
+  languageTracks,
+  TIMELINE_FROM,
+  TIMELINE_TO,
+} from "../data/cv.ts";
+
+const SPAN = TIMELINE_TO - TIMELINE_FROM;
+const pct = (year: number) => ((year - TIMELINE_FROM) / SPAN) * 100;
+
+/** Year gridlines, every 2 years to stay readable. */
+const ticks: number[] = [];
+for (let y = TIMELINE_FROM; y <= TIMELINE_TO; y += 2) ticks.push(y);
+
+export function LanguageTimeline() {
+  return (
+    <section className="section section--tight" id="languages">
+      <div className="section__head">
+        <Reveal as="h2" className="section__title">
+          Languages over time
+        </Reveal>
+        <Reveal as="p" className="section__sub">
+          Which programming languages I was reaching for, and when —{" "}
+          {TIMELINE_FROM} to {TIMELINE_TO}.
+        </Reveal>
+      </div>
+
+      <Reveal className="lang">
+        <div className="lang__axis" aria-hidden="true">
+          <span className="lang__axis-spacer" />
+          <div className="lang__axis-years">
+            {ticks.map((y) => (
+              <span key={y} className="lang__year" style={{ left: `${pct(y)}%` }}>
+                {`'${String(y).slice(2)}`}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <ul className="lang__rows">
+          {languageTracks.map((track) => (
+            <li className="lang__row" key={track.name}>
+              <span className="lang__name">{track.name}</span>
+              <div className="lang__track">
+                {ticks.map((y) => (
+                  <span
+                    key={y}
+                    className="lang__grid"
+                    style={{ left: `${pct(y)}%` }}
+                    aria-hidden="true"
+                  />
+                ))}
+                {track.spans.map((sp, i) => (
+                  <span
+                    key={i}
+                    className="lang__bar"
+                    title={`${track.name}${track.note ? ` — ${track.note}` : ""}`}
+                    style={{
+                      left: `${pct(sp.from)}%`,
+                      width: `${pct(sp.to) - pct(sp.from)}%`,
+                      background: track.color,
+                    }}
+                  >
+                    <span className="lang__bar-sheen" aria-hidden="true" />
+                  </span>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </Reveal>
+    </section>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { Theme } from "../hooks/useTheme.ts";
 import { ThemeToggle } from "./ThemeToggle.tsx";
-import { DownloadIcon } from "./icons.tsx";
+import { DownloadCV } from "./DownloadCV.tsx";
 
 interface Props {
   theme: Theme;
@@ -26,16 +26,14 @@ export function Nav({ theme, onToggleTheme }: Props) {
         </a>
         <nav className="nav__links">
           <a className="nav__link" href="#experience">Experience</a>
+          <a className="nav__link" href="#languages">Languages</a>
           <a className="nav__link" href="#projects">Projects</a>
           <a className="nav__link" href="#skills">Skills</a>
-          <button
-            type="button"
-            className="btn btn--primary"
-            onClick={() => window.print()}
-          >
-            <DownloadIcon />
-            CV
-          </button>
+          <a className="nav__link" href="#education">Education</a>
+          <a className="nav__link nav__game" href="/game/" title="The gamified version">
+            ▶ Game
+          </a>
+          <DownloadCV />
           <ThemeToggle theme={theme} onToggle={onToggleTheme} />
         </nav>
       </div>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,28 +1,40 @@
-import { projects } from "../data/cv.ts";
 import { Reveal } from "./Reveal.tsx";
+import { projects } from "../data/cv.ts";
 
 export function Projects() {
   return (
-    <section className="section" id="projects">
-      <div className="container">
-        <Reveal className="section__head">
-          <span className="section__num">02</span>
-          <h2 className="section__title">Selected Projects</h2>
+    <section className="section section--tight" id="projects">
+      <div className="section__head">
+        <Reveal as="h2" className="section__title">
+          Selected projects
         </Reveal>
-
-        <div className="projects">
-          {projects.map((p, i) => (
-            <Reveal key={p.name} as="article" className="project" delay={i * 60}>
-              <h3 className="project__name">{p.name}</h3>
-              <p className="project__desc">{p.description}</p>
-              <div className="tags">
-                {p.tags.map((t) => (
-                  <span className="tag" key={t}>{t}</span>
-                ))}
-              </div>
+        <Reveal as="p" className="section__sub">
+          Side projects, hackathons and games — where the curiosity goes.
+        </Reveal>
+      </div>
+      <div className="projects">
+        {projects.map((p, i) => {
+          const Tag = p.url ? "a" : "div";
+          return (
+            <Reveal className="project" key={p.name} delay={i * 60}>
+              <Tag
+                className="project__inner"
+                {...(p.url ? { href: p.url, target: "_blank", rel: "noreferrer" } : {})}
+              >
+                <div className="project__head">
+                  <h3 className="project__name">{p.name}</h3>
+                  {p.year && <span className="project__year">{p.year}</span>}
+                </div>
+                <p className="project__desc">{p.description}</p>
+                <ul className="project__tags">
+                  {p.tags.map((t) => (
+                    <li key={t}>{t}</li>
+                  ))}
+                </ul>
+              </Tag>
             </Reveal>
-          ))}
-        </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/components/ScrollMinimap.tsx
+++ b/src/components/ScrollMinimap.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+import { experience } from "../data/cv.ts";
+
+interface Marker {
+  company: string;
+  year: string;
+  /** 0–1 position along the rail (by DOM offset within the section). */
+  pos: number;
+}
+
+/**
+ * A fixed right-hand "minimap" that shows how far you've scrolled into the
+ * history of the experience section, with a marker per role. Hidden on small
+ * screens and under reduced-motion-insensitive layouts via CSS.
+ */
+export function ScrollMinimap() {
+  const [markers, setMarkers] = useState<Marker[]>([]);
+  const [progress, setProgress] = useState(0);
+  const [visible, setVisible] = useState(false);
+  const raf = useRef(0);
+
+  useEffect(() => {
+    const section = document.getElementById("experience");
+    if (!section) return;
+
+    const measure = () => {
+      const items = Array.from(
+        section.querySelectorAll<HTMLElement>(".exp__item"),
+      );
+      const secTop = section.offsetTop;
+      const secH = section.offsetHeight || 1;
+      const next: Marker[] = items.map((el, i) => {
+        const center = el.offsetTop - secTop + el.offsetHeight / 2;
+        const role = experience[i];
+        return {
+          company: role?.company ?? el.dataset.company ?? "",
+          year: role ? `'${String(Math.floor(role.start)).slice(2)}` : "",
+          pos: Math.min(1, Math.max(0, center / secH)),
+        };
+      });
+      setMarkers(next);
+    };
+
+    const update = () => {
+      raf.current = 0;
+      const rect = section.getBoundingClientRect();
+      const vh = window.innerHeight;
+      const mid = vh / 2;
+      const p = (mid - rect.top) / rect.height;
+      setProgress(Math.min(1, Math.max(0, p)));
+      setVisible(rect.top < vh * 0.6 && rect.bottom > vh * 0.4);
+    };
+
+    const onScroll = () => {
+      if (!raf.current) raf.current = requestAnimationFrame(update);
+    };
+
+    measure();
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", () => {
+      measure();
+      update();
+    });
+    // Re-measure shortly after mount once reveal animations settle.
+    const t = setTimeout(measure, 600);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (raf.current) cancelAnimationFrame(raf.current);
+      clearTimeout(t);
+    };
+  }, []);
+
+  const goTo = (i: number) => {
+    const items = document.querySelectorAll<HTMLElement>("#experience .exp__item");
+    items[i]?.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
+  if (markers.length === 0) return null;
+
+  return (
+    <aside
+      className={`minimap${visible ? " is-visible" : ""}`}
+      aria-hidden="true"
+    >
+      <span className="minimap__cap minimap__cap--top">now</span>
+      <div className="minimap__rail">
+        <span
+          className="minimap__fill"
+          style={{ height: `${progress * 100}%` }}
+        />
+        <span className="minimap__thumb" style={{ top: `${progress * 100}%` }} />
+        {markers.map((m, i) => {
+          const reached = progress >= m.pos - 0.04;
+          return (
+            <button
+              type="button"
+              key={m.company}
+              className={`minimap__node${reached ? " is-reached" : ""}`}
+              style={{ top: `${m.pos * 100}%` }}
+              onClick={() => goTo(i)}
+              tabIndex={-1}
+            >
+              <span className="minimap__node-dot" />
+              <span className="minimap__node-label">
+                {m.company} <em>{m.year}</em>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      <span className="minimap__cap minimap__cap--bot">2012</span>
+    </aside>
+  );
+}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,27 +1,31 @@
-import { skills } from "../data/cv.ts";
 import { Reveal } from "./Reveal.tsx";
+import { skills } from "../data/cv.ts";
 
 export function Skills() {
   return (
-    <section className="section" id="skills">
-      <div className="container">
-        <Reveal className="section__head">
-          <span className="section__num">03</span>
-          <h2 className="section__title">Technical Skills</h2>
+    <section className="section section--tight" id="skills">
+      <div className="section__head">
+        <Reveal as="h2" className="section__title">
+          Technical skills
         </Reveal>
-
-        <div className="skills">
-          {skills.map((group, i) => (
-            <Reveal key={group.label} className="skillgroup" delay={i * 50}>
-              <h3 className="skillgroup__label">{group.label}</h3>
-              <div className="skillgroup__items">
-                {group.items.map((item) => (
-                  <span className="chip" key={item}>{item}</span>
-                ))}
-              </div>
-            </Reveal>
-          ))}
-        </div>
+        <Reveal as="p" className="section__sub">
+          A decade of accumulated tooling, grouped by what it's for.
+        </Reveal>
+      </div>
+      <div className="skills">
+        {skills.map((group, i) => (
+          <Reveal className="skill" key={group.label} delay={i * 50}>
+            <h3 className="skill__label">
+              <span className="skill__index">{String(i + 1).padStart(2, "0")}</span>
+              {group.label}
+            </h3>
+            <ul className="skill__items">
+              {group.items.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </Reveal>
+        ))}
       </div>
     </section>
   );

--- a/src/cv/CvDocument.tsx
+++ b/src/cv/CvDocument.tsx
@@ -1,0 +1,198 @@
+/**
+ * Deterministic, polished one-page CV rendered with @react-pdf/renderer
+ * (pdfkit under the hood) — NOT the browser's "Print to PDF". Uses only the
+ * built-in Helvetica family so output is byte-stable and offline.
+ *
+ * This module is loaded lazily (on click) to keep the renderer out of the
+ * initial bundle.
+ */
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+  Link,
+  pdf,
+} from "@react-pdf/renderer";
+import {
+  profile,
+  experience,
+  skills,
+  education,
+  certifications,
+  humanLanguages,
+} from "../data/cv.ts";
+
+const ACCENT = "#c4622d";
+const INK = "#1a1a1a";
+const MUTE = "#6a6a6a";
+const LINE = "#dcd6cf";
+
+const s = StyleSheet.create({
+  page: {
+    paddingTop: 34,
+    paddingBottom: 28,
+    paddingHorizontal: 38,
+    fontFamily: "Helvetica",
+    fontSize: 9,
+    color: INK,
+    lineHeight: 1.4,
+  },
+  name: { fontSize: 22, fontFamily: "Helvetica-Bold", letterSpacing: -0.5 },
+  title: { fontSize: 11, color: ACCENT, fontFamily: "Helvetica-Bold", marginTop: 2 },
+  contact: { fontSize: 8.5, color: MUTE, marginTop: 4 },
+  summary: { marginTop: 8, color: "#333", fontSize: 9 },
+  sectionTitle: {
+    fontSize: 9,
+    fontFamily: "Helvetica-Bold",
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+    color: ACCENT,
+    marginBottom: 6,
+  },
+  section: {
+    marginTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: LINE,
+    paddingTop: 8,
+  },
+  role: { marginBottom: 7 },
+  roleHead: { flexDirection: "row", justifyContent: "space-between" },
+  company: { fontFamily: "Helvetica-Bold", fontSize: 10 },
+  roleTitle: { color: "#444", fontSize: 9 },
+  period: { color: MUTE, fontSize: 8.5 },
+  bullet: { flexDirection: "row", marginTop: 2 },
+  dot: { color: ACCENT, marginRight: 4 },
+  bulletText: { flex: 1, fontSize: 8.7, color: "#333" },
+  earlier: { fontSize: 8.7, color: "#333" },
+  twoCol: { flexDirection: "row", gap: 18 },
+  col: { flex: 1 },
+  skillLine: { marginBottom: 3 },
+  skillLabel: { fontFamily: "Helvetica-Bold", fontSize: 8.5 },
+  skillItems: { fontSize: 8.5, color: "#444" },
+  eduItem: { marginBottom: 4 },
+  eduDegree: { fontFamily: "Helvetica-Bold", fontSize: 9 },
+  eduMeta: { fontSize: 8.3, color: MUTE },
+  inline: { fontSize: 8.5, color: "#444" },
+});
+
+/** Latest / most relevant roles, trimmed to fit one page. */
+const FEATURED = experience.slice(0, 4);
+const MAX_BULLETS = [3, 2, 2, 2];
+/** Compact, grouped skills for the print version. */
+const PRINT_SKILLS = [
+  "Languages",
+  "Backend & Frameworks",
+  "Architecture & Patterns",
+  "Payments & Compliance",
+  "Cloud & DevOps",
+  "AI-Assisted Engineering",
+];
+
+function CvDocument() {
+  const featuredKeys = new Set(FEATURED.map((r) => r.company));
+  const earlier = experience.filter((r) => !featuredKeys.has(r.company));
+
+  return (
+    <Document
+      title={`${profile.name} — CV`}
+      author={profile.name}
+      subject="Curriculum Vitae"
+    >
+      <Page size="A4" style={s.page}>
+        <View>
+          <Text style={s.name}>{profile.name}</Text>
+          <Text style={s.title}>
+            {profile.title} · {profile.tagline}
+          </Text>
+          <Text style={s.contact}>
+            {profile.location} · {profile.email} ·{" "}
+            <Link src={profile.linkedinUrl}>{profile.linkedin}</Link> ·{" "}
+            <Link src={profile.githubUrl}>{profile.github}</Link>
+          </Text>
+          <Text style={s.summary}>{profile.summary}</Text>
+        </View>
+
+        <View style={s.section}>
+          <Text style={s.sectionTitle}>Experience</Text>
+          {FEATURED.map((role, i) => (
+            <View key={role.company} style={s.role} wrap={false}>
+              <View style={s.roleHead}>
+                <Text style={s.company}>
+                  {role.company}
+                  <Text style={s.roleTitle}> — {role.role}</Text>
+                </Text>
+                <Text style={s.period}>{role.period}</Text>
+              </View>
+              {role.highlights.slice(0, MAX_BULLETS[i]).map((h) => (
+                <View key={h} style={s.bullet}>
+                  <Text style={s.dot}>›</Text>
+                  <Text style={s.bulletText}>{h}</Text>
+                </View>
+              ))}
+            </View>
+          ))}
+          <Text style={s.earlier}>
+            <Text style={{ fontFamily: "Helvetica-Bold" }}>Earlier: </Text>
+            {earlier
+              .map((r) => `${r.company} (${r.period.replace(/\s/g, " ")})`)
+              .join("  ·  ")}{" "}
+            — .NET microservices, GovTech portals, B2B logistics & desktop apps.
+          </Text>
+        </View>
+
+        <View style={s.section}>
+          <Text style={s.sectionTitle}>Core Skills</Text>
+          {skills
+            .filter((g) => PRINT_SKILLS.includes(g.label))
+            .map((g) => (
+              <View key={g.label} style={s.skillLine}>
+                <Text>
+                  <Text style={s.skillLabel}>{g.label}: </Text>
+                  <Text style={s.skillItems}>{g.items.join(" · ")}</Text>
+                </Text>
+              </View>
+            ))}
+        </View>
+
+        <View style={s.section}>
+          <View style={s.twoCol}>
+            <View style={s.col}>
+              <Text style={s.sectionTitle}>Education</Text>
+              {education.map((e) => (
+                <View key={e.degree} style={s.eduItem}>
+                  <Text style={s.eduDegree}>{e.degree}</Text>
+                  <Text style={s.eduMeta}>
+                    {e.school} · {e.period}
+                  </Text>
+                </View>
+              ))}
+              <Text style={[s.sectionTitle, { marginTop: 8 }]}>Languages</Text>
+              <Text style={s.inline}>
+                {humanLanguages.map((l) => `${l.language} (${l.level})`).join(" · ")}
+              </Text>
+            </View>
+            <View style={s.col}>
+              <Text style={s.sectionTitle}>Certifications</Text>
+              {certifications.slice(0, 6).map((c) => (
+                <View key={c.name} style={s.bullet}>
+                  <Text style={s.dot}>›</Text>
+                  <Text style={s.bulletText}>
+                    {c.name}
+                    <Text style={s.eduMeta}> — {c.issuer}</Text>
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        </View>
+      </Page>
+    </Document>
+  );
+}
+
+/** Builds the CV as a Blob — deterministic, no Chrome involved. */
+export async function buildCvBlob(): Promise<Blob> {
+  return pdf(<CvDocument />).toBlob();
+}

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -1,6 +1,6 @@
 /**
  * Single source of truth for all portfolio content.
- * Derived from CV_Jevgeni_Rumjantsev_2026.md (latest experience weighted first).
+ * Compiled from the complete career history (ABB 2012 → present).
  * Edit here — every section of the site and the printable CV reads from this file.
  */
 
@@ -15,20 +15,18 @@ export interface Role {
   highlights: string[];
   /** Short tags surfaced under the role (tech / domain keywords). */
   stack?: string[];
-}
-
-export interface EarlierRole {
-  company: string;
-  role: string;
-  period: string;
-  location: string;
-  summary: string;
+  /** Domain ids this role belongs to — drives the domain selector highlight. */
+  domains: DomainId[];
+  /** Decimal years used by the right-hand timeline minimap (e.g. 2012.5). */
+  start: number;
+  end: number;
 }
 
 export interface Project {
   name: string;
   description: string;
   tags: string[];
+  year?: string;
   url?: string;
 }
 
@@ -37,49 +35,173 @@ export interface SkillGroup {
   items: string[];
 }
 
-export interface Education {
+export interface EducationItem {
   degree: string;
+  school: string;
   period: string;
+  note?: string;
 }
+
+export interface Certification {
+  name: string;
+  issuer: string;
+  year?: string;
+}
+
+export interface HumanLanguage {
+  language: string;
+  level: string;
+  /** 0–100 proficiency used for the meter. */
+  proficiency: number;
+}
+
+/** Programming-language usage spans for the colour-coded timeline. */
+export interface LanguageTrack {
+  name: string;
+  color: string;
+  /** Usage windows in decimal years. */
+  spans: { from: number; to: number }[];
+  note?: string;
+}
+
+export type DomainId =
+  | "all"
+  | "crypto"
+  | "payments"
+  | "betting"
+  | "saas"
+  | "content"
+  | "govtech"
+  | "logistics"
+  | "gamedev";
+
+export interface Domain {
+  id: DomainId;
+  label: string;
+  icon: string;
+  /** Generalized, domain-flavoured headline shown in the hero. */
+  blurb: string;
+  /** Accent colour used for the selector + background tint. */
+  color: string;
+}
+
+/** First day of professional work — drives the dynamic "years of experience" panel. */
+export const CAREER_START = new Date("2012-06-20T00:00:00Z");
+
+/** Inclusive bounds for the timeline / minimap axis. */
+export const TIMELINE_FROM = 2012;
+export const TIMELINE_TO = 2026;
 
 export const profile = {
   name: "Jevgeni Rumjantsev",
-  title: "Senior Software Engineer",
-  tagline: "Payments & Fintech · AI-Augmented Delivery",
+  title: "Software Engineer",
+  tagline: "Payments · Crypto · Distributed Systems",
   location: "Barcelona, Spain",
-  phone: "+31 6 457 554 07",
-  phoneHref: "tel:+31645755407",
   email: "zeka.rum@gmail.com",
   linkedin: "linkedin.com/in/jevgenir",
   linkedinUrl: "https://www.linkedin.com/in/jevgenir/",
   github: "github.com/jackinf",
   githubUrl: "https://github.com/jackinf",
   summary:
-    "Senior engineer with 12+ years building scalable, fault-tolerant backends across payments, travel and SaaS. Specialist in high-stakes deposits & withdrawals, banking-vendor integrations and regulatory compliance (CoP/VoP, SEPA). Daily user of AI coding agents — Cursor and Claude Code (agents, skills, schedulers) — to accelerate delivery while keeping production-grade quality. Polyglot in Node.js and Rust; comfortable owning systems end-to-end, on-call and in production.",
+    "Full-stack engineer who has spent over a decade building scalable, fault-tolerant systems end to end — from high-stakes crypto and payments backends to government portals and SaaS platforms. Comfortable owning systems in production, on-call, across a polyglot stack (Node.js, Rust, C#/.NET, Java, Python). Daily user of AI coding agents to ship production-grade software faster.",
 } as const;
 
-/** Compact one-liners shown as animated stats in the hero. */
-export const stats: { value: string; label: string }[] = [
-  { value: "12+", label: "Years engineering" },
-  { value: "Node · Rust", label: "Daily languages" },
-  { value: "Payments", label: "Domain focus" },
-  { value: "AI-augmented", label: "Delivery" },
+/**
+ * Domain selector content. Choosing a domain re-frames the main description and
+ * lights up the roles that belong to it. `all` is the default neutral view.
+ */
+export const domains: Domain[] = [
+  {
+    id: "all",
+    label: "Everything",
+    icon: "✦",
+    blurb:
+      "A polyglot engineer who builds reliable systems end to end — backend, frontend, infra and the glue in between — and has done it across eight very different industries.",
+    color: "#c4622d",
+  },
+  {
+    id: "crypto",
+    label: "Crypto & Exchanges",
+    icon: "₿",
+    blurb:
+      "Owns deposits & withdrawals at a top global crypto exchange — instant local rails, banking-vendor integrations and the on-call ownership that high-value money movement demands.",
+    color: "#f7931a",
+  },
+  {
+    id: "payments",
+    label: "Payments & Fintech",
+    icon: "💳",
+    blurb:
+      "Ships payment systems that move real money: Apple/Google Pay, 3-D Secure 2.0 SCA, SEPA Direct Debit, Confirmation of Payee and multi-vendor banking integrations — measured in conversion and revenue.",
+    color: "#2d7dd2",
+  },
+  {
+    id: "betting",
+    label: "Sports Betting & Data",
+    icon: "🎲",
+    blurb:
+      "Built risk-management and sports-data microservices for a betting & integrity company — pushing business logic out of stored procedures and into tested services, cutting errors threefold.",
+    color: "#16a34a",
+  },
+  {
+    id: "saas",
+    label: "SaaS & Productivity",
+    icon: "📈",
+    blurb:
+      "Architected and led product SaaS — ten CQRS / Event-Sourced microservices for time-tracking, plus team leadership of eight and end-to-end CI/CD ownership.",
+    color: "#7c3aed",
+  },
+  {
+    id: "content",
+    label: "Cloud Content",
+    icon: "🗂️",
+    blurb:
+      "Delivered Digital Signatures and Document Generation for a global secure-content platform — Java & Django backends, React & Vue frontends, all running on Kubernetes.",
+    color: "#0ea5e9",
+  },
+  {
+    id: "govtech",
+    label: "GovTech & Enterprise",
+    icon: "🏛️",
+    blurb:
+      "Lead developer on Estonia's national research-grant portal — X-Road government data exchange, rights management and authentication for enterprise and public-sector clients.",
+    color: "#b45309",
+  },
+  {
+    id: "logistics",
+    label: "Logistics",
+    icon: "📦",
+    blurb:
+      "Architected a B2B parcel-tracking platform from scratch — five .NET microservices, three React frontends and integrations with external delivery carriers.",
+    color: "#0d9488",
+  },
+  {
+    id: "gamedev",
+    label: "Game Dev",
+    icon: "🕹️",
+    blurb:
+      "Builds games for the love of it — a 2D tank game in Rust/Bevy, a multiplayer drawing game, and explorations across Unity, MonoGame and DirectX 11.",
+    color: "#db2777",
+  },
 ];
 
 export const experience: Role[] = [
   {
     company: "Kraken",
     companyNote: "Top global crypto exchange",
-    role: "Senior Software Engineer · Payments",
+    role: "Software Engineer · Payments",
     period: "Apr 2025 – Jun 2026",
     location: "Remote / Amsterdam, NL",
     current: true,
+    domains: ["crypto", "payments"],
+    start: 2025.25,
+    end: 2026.45,
     highlights: [
-      "Owned deposits & withdrawals on the Payments team, shipping in Node.js and Rust (≈50/50) for a top global crypto exchange.",
+      "Owned deposits & withdrawals on the Payments team, shipping in Node.js and Rust (~50/50) for a top global crypto exchange.",
       "Delivered Blik Deposits and Blik Instant Buy, expanding instant local payment coverage for Polish users.",
       "Implemented Confirmation/Verification of Payee (CoP/VoP) name-matching to cut misdirected payments and meet anti-fraud requirements.",
       "Built a SEPA Direct Debit notification system to keep the platform SEPA-compliant, plus automatic returns via Ivy to streamline failed-payment handling.",
-      "Integrated and operated multiple banking vendors — Banking Circle, Ivy, OpenPayd, Plaid — and carried on-call ownership for live payment incidents.",
+      "Integrated and operated 4 banking vendors — Banking Circle, Ivy, OpenPayd and Plaid — and carried on-call ownership for live payment incidents.",
       "Drove AI-augmented delivery: built internal tooling and used Claude Code agents with up-to-date practices (skills, schedulers, Obsidian as long-term memory) to raise team productivity.",
     ],
     stack: ["Node.js", "Rust", "SEPA", "CoP/VoP", "Blik", "On-call"],
@@ -90,72 +212,238 @@ export const experience: Role[] = [
     role: "Senior Software Engineer",
     period: "Apr 2022 – Apr 2025",
     location: "Amsterdam, NL",
+    domains: ["content", "saas"],
+    start: 2022.25,
+    end: 2025.25,
     highlights: [
-      "Built Digital Signatures and Document Generation products in scrum teams; Java & Django backends with React & Vue frontends.",
-      "Configured infrastructure as code and ran workloads on Kubernetes; developed tooling in Python, TypeScript and Rust.",
+      "Developed the Digital Signatures application within scrum teams for an enterprise content platform used globally.",
+      "Built the Document Generation application end to end.",
+      "Worked across Java and Django (Python) backends with React and Vue frontends.",
+      "Configured infrastructure as code (Terraform / Terragrunt) and ran workloads on Kubernetes.",
+      "Developed internal tooling in Python, TypeScript and Rust.",
     ],
-    stack: ["Java", "Django", "React", "Vue", "Kubernetes", "Rust"],
+    stack: ["Java", "Django", "React", "Vue", "Kubernetes", "Terraform", "Rust"],
   },
   {
     company: "TimeChimp",
-    companyNote: "Time-tracking startup",
+    companyNote: "Time-tracking SaaS",
     role: "Lead Software Engineer",
     period: "Sep 2020 – Mar 2022",
     location: "Amsterdam, NL",
+    domains: ["saas"],
+    start: 2020.7,
+    end: 2022.25,
     highlights: [
-      "Built 10 microservices in .NET applying CQRS and Event Sourcing, with full unit/integration/e2e coverage and a React/TypeScript frontend.",
-      "Owned CI/CD and deployed to Kubernetes + Terraform on Azure; led a team of 8 and partly acted as Scrum Master.",
+      "Architected and built 10 microservices in .NET with performance and scalability in mind.",
+      "Applied CQRS and Event Sourcing patterns across the platform.",
+      "Covered services with unit, integration and end-to-end tests.",
+      "Developed the frontend in React / TypeScript.",
+      "Owned CI/CD pipelines; deployed and maintained applications on Kubernetes + Terraform on Azure.",
+      "Led a team of 8 people and partly performed the responsibilities of Scrum Master.",
     ],
     stack: [".NET", "CQRS", "Event Sourcing", "Azure", "Terraform", "Team lead"],
   },
   {
     company: "Travix",
-    companyNote: "Travel search & booking",
-    role: "Senior Software Engineer",
+    companyNote: "Global travel search & booking",
+    role: "Senior Full-Stack Engineer",
     period: "Sep 2018 – Aug 2020",
     location: "Amsterdam, NL",
+    domains: ["payments"],
+    start: 2018.7,
+    end: 2020.65,
     highlights: [
-      "Developed payments-module microservices and a React/TypeScript frontend; introduced Google Pay & Apple Pay, lifting turnover.",
-      "Deployed cron jobs on Kubernetes / Google Cloud Platform.",
+      "Developed microservices and a React / TypeScript frontend for the payments module.",
+      "Introduced Google Pay & Apple Pay as payment options, lifting revenue by ~10%.",
+      "Delivered the 3-D Secure 2.0 (Strong Customer Authentication) standard, improving security and increasing conversions by hundreds of thousands of euros.",
+      "Rebuilt the Virtual Card Number (VCN) service from a monolith into microservices for maintainability.",
+      "Created internal deployment tooling that reduced rollout time from 1 working day to 2 hours.",
+      "Contributed to GDPR-compliance work — wrote scripts to retrieve data from incorrectly indexed NoSQL databases, removed sensitive records and made queries ~10x faster via cleanup and obfuscation.",
+      "Automated long-running end-to-end tests across 40 affiliates.",
+      "Maintained payments backends in .NET and Node.js, plus the React frontend; ran cron jobs on Kubernetes in Google Cloud Platform.",
     ],
-    stack: ["Microservices", "React", "Google Pay", "Apple Pay", "GCP"],
+    stack: ["Microservices", "React", "Google Pay", "Apple Pay", "3DS 2.0", "GCP"],
   },
-];
-
-export const earlier: EarlierRole[] = [
   {
     company: "Genius Sports",
-    role: "Software Engineer",
+    companyNote: "Sports data, technology & betting integrity",
+    role: "Software Engineer · .NET",
     period: "Jun 2017 – Aug 2018",
-    location: "Tallinn",
-    summary: "Built unit-tested, high-performance .NET microservices for sports data.",
+    location: "Tallinn, Estonia",
+    domains: ["betting"],
+    start: 2017.45,
+    end: 2018.65,
+    highlights: [
+      "Developed unit-tested microservices in .NET with performance and scalability in mind.",
+      "Designed microservices for a Risk Management system, resulting in 3x fewer errors.",
+      "Migrated business logic from database stored procedures into a tested backend, making the system less error-prone.",
+      "Integrated pub/sub messaging (AMQP) for inter-service communication.",
+      "Maintained a legacy desktop application and acted as Release Manager, synchronising versions across microservices.",
+      "Wrote T-SQL scripts, worked with TeamCity and Jenkins CI, and built & deployed Docker images.",
+    ],
+    stack: [".NET", "AMQP", "Docker", "TeamCity", "T-SQL", "Release mgmt"],
   },
   {
     company: "Finestmedia",
-    role: "Software Engineer",
-    period: "Aug 2013 – Jun 2017",
-    location: "Tallinn",
-    summary: "Developed the Estonian Government application-submission portal (.NET Framework).",
+    companyNote: "B2B / government & enterprise IT",
+    role: "Senior Full-Stack Engineer · Lead Developer",
+    period: "Nov 2013 – Jun 2017",
+    location: "Tallinn, Estonia",
+    domains: ["govtech"],
+    start: 2013.85,
+    end: 2017.45,
+    highlights: [
+      "Developed Estonia's national research-grant submission portal (3 years) — ASP MVC, ASP Web API, ASMX/WCF.",
+      "Worked with X-Road, the Estonian government data-exchange layer, making cross-system data more secure.",
+      "Implemented rights-management and authentication systems.",
+      "Set up and optimized RavenDB (NoSQL): query optimization, database structure and setup.",
+      "Built a file-uploading component that made uploads 5x faster and considerably safer.",
+      "Promoted to Lead Developer on the portal; established and maintained the Git workflow.",
+      "Earlier project (KopioNiini, 1 year): ASP MVC 4, Angular, MongoDB, with extensive testing.",
+      "In 2017, helped a startup build a digital invoicing system using microservices, Entity Framework and Angular.",
+    ],
+    stack: ["ASP MVC", "Angular", "X-Road", "RavenDB", "WCF", "Lead dev"],
   },
   {
-    company: "Speys",
-    role: "Software Engineer (part-time)",
-    period: "Jun 2017 – Jun 2019",
-    location: "Remote",
-    summary: "Built 5 .NET microservices and 3 React/TS frontends for B2B parcel tracking.",
+    company: "Speys (SpeysCloud)",
+    companyNote: "Finnish logistics automation",
+    role: "Full-Stack .NET Developer · Contract",
+    period: "Jan 2017 – Aug 2019 (intermittent)",
+    location: "Finland (remote)",
+    domains: ["logistics"],
+    start: 2017.0,
+    end: 2019.65,
+    highlights: [
+      "Architected the entire system from scratch — frontend, backend and CI/CD.",
+      "Built 5 microservices in .NET (email, translations, authentication, delivery and more).",
+      "Built 3 frontends in React / TypeScript for B2B parcel-tracking use cases.",
+      "Used a JWT Authority Server, .NET Core Web API, React + Redux + TypeScript, Docker and Azure.",
+      "Architected B2B integrations with other package-delivery services.",
+    ],
+    stack: [".NET Core", "React", "Redux", "Docker", "Azure", "JWT"],
+  },
+  {
+    company: "ABB",
+    companyNote: "Global electrification & automation",
+    role: "Junior .NET Engineer",
+    period: "Jun 2012 – Dec 2012",
+    location: "Jüri, Estonia",
+    domains: ["govtech"],
+    start: 2012.45,
+    end: 2012.95,
+    highlights: [
+      "Imported data from Excel into MSSQL, mapped/reduced it and displayed it in WinForms charts; extensive work with MSSQL functions and stored procedures.",
+      "Built a WPF program for working with tabular data — searching, grouping, sorting and pagination over different statuses.",
+      "Built an ASP MVC safety questionnaire for company workers.",
+      "Built a WPF statistical-analytics application for accident data; contributed to a 3x reduction in workplace accidents.",
+    ],
+    stack: ["C#", "WPF", "WinForms", "ASP MVC", "MSSQL"],
   },
 ];
 
 export const projects: Project[] = [
   {
-    name: "Jira & GitHub aggregator",
-    description: "Internal CLI fully in Rust leveraging traits & async (Tokio).",
-    tags: ["Rust", "Tokio", "CLI"],
+    name: "Charlie-seven",
+    description:
+      "A real-time multiplayer drawing & guessing game built in December 2025 — players sketch on a shared canvas while others race to guess the prompt.",
+    tags: ["TypeScript", "Realtime", "WebSockets", "Canvas", "Game"],
+    year: "2025",
+  },
+  {
+    name: "Triven / Skynda",
+    description:
+      "A platform to make buying & selling cars easier, built in a 48-hour Garage48 hackathon with a team of 7.",
+    tags: [".NET", "Spring Boot", "React", "Redux", "EF Core", "Hackathon"],
+    year: "2016",
   },
   {
     name: "Tank game",
-    description: "2D top-down game built on the Bevy engine (100% Rust).",
-    tags: ["Rust", "Bevy", "Game dev"],
+    description:
+      "A 2D top-down tank game written entirely in Rust on the Bevy game engine.",
+    tags: ["Rust", "Bevy", "ECS", "Game dev"],
+  },
+  {
+    name: "Jira & GitHub aggregator",
+    description:
+      "A developer-productivity CLI written entirely in Rust, leaning on traits and async (Tokio) to merge Jira and GitHub activity.",
+    tags: ["Rust", "Tokio", "Async", "CLI"],
+  },
+  {
+    name: "Space shooter explorations",
+    description:
+      "Game-dev learning across DirectX 11 (C++), MonoGame (C#) and Unity — sprites, animation, 3D modelling basics and a Unity mini-game shooting asteroids around a sphere.",
+    tags: ["Unity", "MonoGame", "DirectX 11", "C++", "C#"],
+  },
+  {
+    name: "This portfolio + gamified CV",
+    description:
+      "This site (Bun + React 19) plus a sidescroller game that tells the same story — built and maintained with AI coding agents.",
+    tags: ["React", "Bun", "TypeScript", "Canvas"],
+    url: "/game/",
+  },
+];
+
+/**
+ * Programming-language usage over time. Spans are decimal years and drive the
+ * colour-coded horizontal timeline panel.
+ */
+export const languageTracks: LanguageTrack[] = [
+  {
+    name: "C# / .NET",
+    color: "#9b4dca",
+    spans: [{ from: 2012.45, to: 2022.25 }],
+    note: "Primary language for a decade",
+  },
+  {
+    name: "SQL",
+    color: "#0d9488",
+    spans: [{ from: 2012.45, to: 2026.45 }],
+    note: "T-SQL → PostgreSQL",
+  },
+  {
+    name: "JavaScript / TypeScript",
+    color: "#2563eb",
+    spans: [{ from: 2013.85, to: 2026.45 }],
+    note: "TS from ~2016 onward",
+  },
+  {
+    name: "Angular",
+    color: "#dd0031",
+    spans: [{ from: 2013.85, to: 2017.45 }],
+  },
+  {
+    name: "React",
+    color: "#06b6d4",
+    spans: [{ from: 2017.0, to: 2026.45 }],
+  },
+  {
+    name: "Java",
+    color: "#e76f00",
+    spans: [
+      { from: 2016.75, to: 2016.95 },
+      { from: 2022.25, to: 2025.25 },
+    ],
+  },
+  {
+    name: "C++",
+    color: "#6c8ebf",
+    spans: [{ from: 2019.0, to: 2021.5 }],
+    note: "Game-dev exploration",
+  },
+  {
+    name: "Rust",
+    color: "#c0613a",
+    spans: [{ from: 2021.5, to: 2026.45 }],
+  },
+  {
+    name: "Python",
+    color: "#3776ab",
+    spans: [{ from: 2022.25, to: 2026.45 }],
+  },
+  {
+    name: "Vue",
+    color: "#42b883",
+    spans: [{ from: 2022.25, to: 2025.25 }],
   },
 ];
 
@@ -163,57 +451,167 @@ export const skills: SkillGroup[] = [
   {
     label: "Languages",
     items: [
-      "Node.js / TypeScript",
-      "Rust (Tokio)",
-      "C# / .NET Core",
-      "Java / Spring Boot",
-      "Python / Django",
-      "JavaScript",
+      "TypeScript / JavaScript",
+      "Rust",
+      "C# / .NET",
+      "Java",
+      "Python",
+      "SQL (T-SQL, PostgreSQL)",
+      "C++",
+      "Bash / PowerShell",
     ],
   },
   {
-    label: "AI-Assisted Development",
+    label: "Backend & Frameworks",
     items: [
-      "Cursor",
-      "Claude Code (agents, skills, schedulers)",
-      "Obsidian long-term memory",
-      "Prompt engineering for agentic workflows",
+      ".NET Core / Framework",
+      "Node.js",
+      "Spring Boot",
+      "Django",
+      "Entity Framework / EF Core",
+      "NServiceBus",
+      "MassTransit",
+      "MediatR",
+      "WPF / WinForms",
+      "WCF / ASMX",
+    ],
+  },
+  {
+    label: "Frontend",
+    items: [
+      "React",
+      "Vue",
+      "Angular",
+      "Redux / MobX / RxJS",
+      "HTML5 / CSS / SASS",
+      "Webpack / Gulp / Grunt",
+      "Canvas / WebSockets",
+    ],
+  },
+  {
+    label: "Architecture & Patterns",
+    items: [
+      "Microservices / SOA",
+      "CQRS",
+      "Event Sourcing",
+      "Domain-Driven Design",
+      "REST APIs",
+      "Pub/Sub messaging (AMQP)",
+      "Distributed systems",
     ],
   },
   {
     label: "Payments & Compliance",
     items: [
-      "Banking Circle",
-      "Ivy",
-      "OpenPayd",
-      "Plaid",
-      "CoP/VoP",
       "SEPA Direct Debit",
-      "Blik",
+      "Confirmation / Verification of Payee",
+      "3-D Secure 2.0 (SCA)",
+      "Apple Pay / Google Pay",
+      "Blik instant payments",
+      "PCI / GDPR awareness",
+      "Banking Circle · Ivy · OpenPayd · Plaid",
       "On-call incident response",
     ],
   },
   {
-    label: "Data",
-    items: ["PostgreSQL", "MSSQL", "Redis", "MongoDB", "RavenDB", "ElasticSearch"],
+    label: "Data & Storage",
+    items: [
+      "PostgreSQL",
+      "MSSQL / SQL Server",
+      "MongoDB",
+      "RavenDB",
+      "Redis",
+      "ElasticSearch",
+    ],
   },
   {
     label: "Cloud & DevOps",
     items: [
-      "GCP",
-      "Azure",
-      "Docker",
       "Kubernetes",
+      "Docker",
       "Terraform / Terragrunt",
-      "Git",
-      "CQRS",
-      "Event Sourcing",
-      "Auth0",
+      "Google Cloud Platform",
+      "Microsoft Azure",
+      "CircleCI · TeamCity · Jenkins · Octopus",
+      "IIS",
     ],
+  },
+  {
+    label: "Security & Auth",
+    items: [
+      "JWT / OpenIddict",
+      "Auth0",
+      "X-Road government data exchange",
+      "Rights management",
+    ],
+  },
+  {
+    label: "AI-Assisted Engineering",
+    items: [
+      "Claude Code (agents, skills, schedulers)",
+      "Cursor",
+      "Obsidian long-term memory",
+      "Agentic workflow design",
+      "Prompt engineering",
+    ],
+  },
+  {
+    label: "Testing & QA",
+    items: [
+      "xUnit / NUnit / Moq",
+      "Jasmine / Chai",
+      "Selenium / Nightwatch",
+      "Unit · Integration · E2E",
+    ],
+  },
+  {
+    label: "Game Dev",
+    items: ["Bevy (Rust)", "Unity", "MonoGame", "DirectX 11", "ECS"],
+  },
+  {
+    label: "Tooling",
+    items: ["Git (GitHub, GitLab)", "Postman", "Tokio (async)", "SVN / TFS (legacy)"],
   },
 ];
 
-export const education: Education[] = [
-  { degree: "M.Sc. Software Engineering", period: "2014 – 2015" },
-  { degree: "B.Sc. Software Engineering", period: "2010 – 2013" },
+export const education: EducationItem[] = [
+  {
+    degree: "M.Sc. — Computer Science Engineering",
+    school: "Tallinn University of Technology",
+    period: "2014 – 2015",
+  },
+  {
+    degree: "B.Sc. — Computer Science Engineering",
+    school: "Tallinn University of Technology",
+    period: "2010 – 2013",
+    note: "Business Information Technology",
+  },
+];
+
+export const certifications: Certification[] = [
+  { name: "Microsoft Certified Solutions Developer (MCSD)", issuer: "Microsoft" },
+  { name: "Microsoft Certified Professional", issuer: "Microsoft" },
+  {
+    name: "Programming in HTML5 with JavaScript & CSS3 — Specialist",
+    issuer: "Microsoft",
+    year: "2014",
+  },
+  { name: "Developing Web Applications", issuer: "Microsoft", year: "2014" },
+  { name: "Architecting with Google Cloud Platform", issuer: "Google Cloud" },
+  { name: "Architecting with Kubernetes", issuer: "Google Cloud" },
+  {
+    name: "Divide & Conquer, Sorting, Searching & Randomized Algorithms",
+    issuer: "Stanford / Coursera",
+  },
+  {
+    name: "Advanced CSS and Sass: Flexbox, Grid, Animations",
+    issuer: "Udemy",
+  },
+];
+
+export const humanLanguages: HumanLanguage[] = [
+  { language: "Russian", level: "Native", proficiency: 100 },
+  { language: "English", level: "Fluent", proficiency: 95 },
+  { language: "Estonian", level: "Fluent", proficiency: 90 },
+  { language: "German", level: "Basic", proficiency: 30 },
 ];

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks which section id is currently dominant in the viewport. Drives the
+ * section-aware animated background and the nav highlight.
+ */
+export function useActiveSection(ids: string[], fallback = ids[0]) {
+  const [active, setActive] = useState(fallback);
+
+  useEffect(() => {
+    const els = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (els.length === 0) return;
+
+    const ratios = new Map<string, number>();
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) ratios.set(e.target.id, e.intersectionRatio);
+        let best = fallback;
+        let bestRatio = -1;
+        for (const [id, r] of ratios) {
+          if (r > bestRatio) {
+            bestRatio = r;
+            best = id;
+          }
+        }
+        if (bestRatio > 0) setActive(best);
+      },
+      { threshold: [0, 0.15, 0.3, 0.5, 0.75, 1], rootMargin: "-45% 0px -45% 0px" },
+    );
+
+    els.forEach((el) => obs.observe(el));
+    return () => obs.disconnect();
+  }, [ids.join("|"), fallback]);
+
+  return active;
+}

--- a/src/hooks/useScrollProgress.ts
+++ b/src/hooks/useScrollProgress.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a 0–1 scroll progress for a given element: 0 when its top reaches the
+ * viewport, 1 when its bottom leaves. Used by the experience-history minimap.
+ */
+export function useScrollProgress(elementId: string) {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const el = document.getElementById(elementId);
+    if (!el) return;
+
+    let raf = 0;
+    const update = () => {
+      raf = 0;
+      const rect = el.getBoundingClientRect();
+      const vh = window.innerHeight;
+      // Distance scrolled through the element, normalised.
+      const total = rect.height + vh;
+      const scrolled = vh - rect.top;
+      const p = Math.min(1, Math.max(0, scrolled / total));
+      setProgress(p);
+    };
+    const onScroll = () => {
+      if (!raf) raf = requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [elementId]);
+
+  return progress;
+}

--- a/src/lib/highlight.tsx
+++ b/src/lib/highlight.tsx
@@ -1,0 +1,25 @@
+import { Fragment, type ReactNode } from "react";
+
+/**
+ * Matches the "interesting" numeric tokens we want to visually emphasise:
+ * percentages (~10%), multipliers (3x), ratios (~50/50), the phrase
+ * "hundreds of thousands", and standalone numbers / years — while avoiding
+ * digits that live inside words or product names (HTML5, Auth0, 3-D Secure).
+ */
+const TOKEN =
+  /(~?\d+(?:[.,]\d+)?%|\b\d+x\b|~?\d+\/\d+|hundreds of thousands|(?<![\w.-])\d+(?:[.,]\d+)?(?![\w.%x-]))/gi;
+
+/** Wraps numbers & achievements in <strong class="num"> for highlighting. */
+export function highlightNumbers(text: string): ReactNode {
+  const parts = text.split(TOKEN);
+  return parts.map((part, i) =>
+    // Odd indices are the captured matches.
+    i % 2 === 1 ? (
+      <strong className="num" key={i}>
+        {part}
+      </strong>
+    ) : (
+      <Fragment key={i}>{part}</Fragment>
+    ),
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -607,3 +607,830 @@ main {
   height: 18px;
   flex: none;
 }
+
+/* ================================================================== *
+ *  v2 — domain spinner, animated background, timeline, minimap, etc.  *
+ *  Appended block. Overrides earlier rules where selectors collide.   *
+ * ================================================================== */
+
+/* ---- Content centering (replaces the old .container wrappers) ---- */
+.section {
+  border-top: none;
+  position: relative;
+}
+.section--tight {
+  padding-block: clamp(2.5rem, 1.5rem + 4vw, 4.5rem);
+}
+.section > *,
+.hero > * {
+  max-width: var(--maxw);
+  margin-inline: auto;
+  padding-inline: clamp(1.25rem, 0.5rem + 3vw, 2.5rem);
+}
+
+/* Section heads now stack title + subtitle. */
+.section__head {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+}
+.section__sub {
+  color: var(--text-muted);
+  font-size: var(--text-base);
+  max-width: 62ch;
+}
+
+/* ================= Animated background ================= */
+.bg {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  overflow: hidden;
+  pointer-events: none;
+  --c1: var(--accent);
+  --c2: var(--accent);
+}
+.bg__layer {
+  position: absolute;
+  inset: 0;
+  transition: opacity 0.9s var(--ease), background 0.9s var(--ease);
+}
+.bg__layer--pattern {
+  opacity: 0.5;
+  background-image: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--c1) 26%, transparent) 1px,
+    transparent 1.4px
+  );
+  background-size: 26px 26px;
+}
+.bg__layer--gradient {
+  background: radial-gradient(
+    1200px 700px at 80% -5%,
+    color-mix(in srgb, var(--c1) 10%, transparent),
+    transparent 60%
+  );
+}
+.bg__layer--blob {
+  width: 46vw;
+  height: 46vw;
+  border-radius: 50%;
+  filter: blur(70px);
+  opacity: 0.22;
+  transition: background 0.9s var(--ease), transform 1.2s var(--ease);
+  will-change: transform;
+}
+.bg__layer--blob-a {
+  top: -12vw;
+  left: -8vw;
+  background: var(--c1);
+  animation: floatA 22s ease-in-out infinite;
+}
+.bg__layer--blob-b {
+  bottom: -14vw;
+  right: -6vw;
+  background: var(--c2);
+  animation: floatB 26s ease-in-out infinite;
+}
+[data-theme="dark"] .bg__layer--blob {
+  opacity: 0.3;
+}
+@keyframes floatA {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(6vw, 4vw) scale(1.1); }
+}
+@keyframes floatB {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(-5vw, -4vw) scale(1.08); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .bg__layer--blob { animation: none; }
+}
+
+/* Per-section palette. */
+.bg[data-section="top"]        { --c1: #c4622d; --c2: #f7931a; }
+.bg[data-section="experience"] { --c1: #2d7dd2; --c2: #0ea5e9; }
+.bg[data-section="languages"]  { --c1: #0d9488; --c2: #16a34a; }
+.bg[data-section="projects"]   { --c1: #db2777; --c2: #7c3aed; }
+.bg[data-section="skills"]     { --c1: #0891b2; --c2: #2563eb; }
+.bg[data-section="education"]  { --c1: #b45309; --c2: #d97706; }
+
+/* ================= Hero (v2) ================= */
+.hero__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(1.5rem, 1rem + 3vw, 3rem);
+  align-items: center;
+}
+@media (min-width: 880px) {
+  .hero__grid {
+    grid-template-columns: 1.5fr 1fr;
+  }
+}
+.hero__eyebrow {
+  color: var(--text-subtle);
+  letter-spacing: 0.04em;
+}
+.hero__tagline {
+  margin-top: 0.35rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--accent);
+  letter-spacing: 0.02em;
+}
+.hero__lead {
+  margin-top: 1.4rem;
+  min-height: 6.5em;
+}
+.hero__summary {
+  max-width: 56ch;
+  color: var(--text-muted);
+  font-size: var(--text-lg);
+  animation: heroSwap 0.55s var(--ease);
+}
+@keyframes heroSwap {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hero__summary { animation: none; }
+}
+.hero__contact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+  margin-top: 1.5rem;
+  font-size: var(--text-sm);
+}
+.hero__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-muted);
+  transition: color 0.2s var(--ease);
+}
+.hero__link:hover { color: var(--accent); }
+.hero__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.75rem;
+}
+.btn--ghost {
+  background: transparent;
+}
+
+/* Stats strip (v2) */
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  margin-top: 3rem;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+@media (min-width: 760px) {
+  .hero__stats { grid-template-columns: repeat(6, 1fr); }
+}
+.stat {
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(4px);
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.stat__value {
+  font-family: var(--font-mono);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+.stat__label {
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: 1.3;
+}
+.stat--counter {
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  grid-column: span 1;
+}
+.stat--counter .stat__value {
+  color: var(--accent);
+  font-size: var(--text-xl);
+}
+.stat__ticker {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--text-subtle);
+}
+.stat__decimal { opacity: 0.7; }
+
+/* ================= Domain spinner ================= */
+.spinner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  backdrop-filter: blur(6px);
+  box-shadow: var(--shadow);
+}
+.spinner__picker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+.spinner__arrow {
+  border: none;
+  background: none;
+  color: var(--text-subtle);
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+  transition: color 0.2s var(--ease), transform 0.15s var(--ease);
+}
+.spinner__arrow:hover { color: var(--domain-color, var(--accent)); transform: scale(1.2); }
+.spinner__stage {
+  position: relative;
+  width: 230px;
+  height: 132px;
+  perspective: 640px;
+  outline: none;
+  -webkit-mask-image: linear-gradient(transparent, #000 28%, #000 72%, transparent);
+  mask-image: linear-gradient(transparent, #000 28%, #000 72%, transparent);
+}
+.spinner__wheel {
+  position: absolute;
+  inset: 0;
+  transform-style: preserve-3d;
+  transition: transform 0.5s var(--ease);
+}
+.spinner__item {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 210px;
+  height: 44px;
+  margin-left: -105px;
+  margin-top: -22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  color: var(--text-subtle);
+  backface-visibility: hidden;
+  transition: color 0.3s var(--ease), opacity 0.3s var(--ease);
+}
+.spinner__item.is-selected {
+  color: var(--c, var(--accent));
+}
+.spinner__icon { font-size: 1.2rem; }
+.spinner__label { letter-spacing: -0.01em; white-space: nowrap; }
+
+/* Reduced-motion / flat fallback */
+.spinner__stage.is-flat {
+  height: auto;
+  max-height: 168px;
+  overflow-y: auto;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+.spinner__stage.is-flat .spinner__wheel { position: static; transform: none !important; }
+.spinner__stage.is-flat .spinner__item {
+  position: static;
+  width: 100%;
+  margin: 0;
+  transform: none !important;
+  justify-content: flex-start;
+  padding: 0.35rem 0.5rem;
+}
+
+.spinner__hint {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+}
+
+/* ================= Experience (v2) ================= */
+.exp {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: clamp(1.5rem, 1rem + 2vw, 2.5rem);
+}
+.exp__item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(4px);
+  padding: clamp(1.1rem, 0.8rem + 1vw, 1.6rem);
+  transition: opacity 0.4s var(--ease), border-color 0.3s var(--ease),
+    transform 0.3s var(--ease), box-shadow 0.3s var(--ease), filter 0.4s var(--ease);
+}
+.exp__item:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow);
+}
+.exp__item--current {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+.exp__item--match {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent), var(--shadow);
+}
+.exp__item--dim {
+  opacity: 0.45;
+  filter: saturate(0.55);
+}
+.exp__head {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.25rem 1rem;
+}
+.exp__company {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+.exp__note {
+  font-weight: 400;
+  font-size: var(--text-sm);
+  color: var(--text-subtle);
+}
+.exp__badge {
+  margin-left: 0.6rem;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  vertical-align: middle;
+}
+.exp__role {
+  color: var(--accent);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  margin-top: 0.1rem;
+}
+.exp__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+}
+.exp__period {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text);
+  white-space: nowrap;
+}
+.exp__location {
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+}
+.exp__highlights {
+  list-style: none;
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.exp__highlights li {
+  position: relative;
+  padding-left: 1.2rem;
+  color: var(--text-muted);
+  font-size: var(--text-base);
+  transition: color 0.25s var(--ease);
+}
+.exp__highlights li::before {
+  content: "›";
+  position: absolute;
+  left: 0;
+  top: -0.05em;
+  color: var(--accent);
+  font-weight: 700;
+}
+.exp__highlights li:hover {
+  color: var(--text);
+}
+.num {
+  color: var(--accent);
+  font-weight: 700;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  padding: 0 0.22em;
+  border-radius: 5px;
+}
+.exp__stack {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 1rem;
+}
+.exp__stack li {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  padding: 0.2rem 0.55rem;
+  border-radius: 6px;
+}
+
+/* ================= Language timeline ================= */
+.lang {
+  margin-top: clamp(1.5rem, 1rem + 2vw, 2.5rem);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(4px);
+  padding: clamp(1rem, 0.6rem + 2vw, 2rem);
+  box-shadow: var(--shadow);
+}
+.lang__axis {
+  display: flex;
+  margin-bottom: 0.75rem;
+}
+.lang__axis-spacer { width: 140px; flex: none; }
+.lang__axis-years {
+  position: relative;
+  flex: 1;
+  height: 1.2em;
+}
+.lang__year {
+  position: absolute;
+  transform: translateX(-50%);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+}
+.lang__rows {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+.lang__row {
+  display: flex;
+  align-items: center;
+}
+.lang__name {
+  width: 140px;
+  flex: none;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  padding-right: 0.75rem;
+}
+.lang__track {
+  position: relative;
+  flex: 1;
+  height: 16px;
+  border-radius: 8px;
+  background: var(--surface-2);
+}
+.lang__grid {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
+  width: 1px;
+  background: var(--border);
+  opacity: 0.6;
+}
+.lang__bar {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-radius: 8px;
+  overflow: hidden;
+  min-width: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  transition: filter 0.2s var(--ease);
+}
+.lang__bar:hover { filter: brightness(1.1); }
+.lang__bar-sheen {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.35),
+    rgba(255, 255, 255, 0) 55%
+  );
+}
+@media (max-width: 600px) {
+  .lang__axis-spacer,
+  .lang__name { width: 92px; }
+  .lang__name { font-size: var(--text-xs); }
+}
+
+/* ================= Projects (v2) ================= */
+.projects {
+  margin-top: clamp(1.25rem, 1rem + 1.5vw, 2rem);
+}
+.project {
+  border: none;
+  background: none;
+  padding: 0;
+}
+.project:hover { transform: none; box-shadow: none; }
+.project__inner {
+  display: block;
+  height: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.4rem;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(4px);
+  transition: border-color 0.25s var(--ease), transform 0.25s var(--ease),
+    box-shadow 0.25s var(--ease);
+}
+.project__inner:hover {
+  border-color: var(--accent);
+  transform: translateY(-3px);
+  box-shadow: var(--shadow);
+}
+.project__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+.project__year {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+}
+.project__tags {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.9rem;
+}
+.project__tags li {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  padding: 0.18rem 0.5rem;
+  border-radius: 6px;
+}
+
+/* ================= Skills (v2) ================= */
+.skills {
+  margin-top: clamp(1.25rem, 1rem + 1.5vw, 2rem);
+}
+.skill {
+  break-inside: avoid;
+}
+.skill__label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+}
+.skill__index {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--accent);
+}
+.skill__items {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.skill__items li {
+  font-size: var(--text-sm);
+  color: var(--text);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  padding: 0.28rem 0.65rem;
+  border-radius: 999px;
+  transition: border-color 0.2s var(--ease), color 0.2s var(--ease),
+    background 0.2s var(--ease);
+}
+.skill__items li:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+/* ================= Education (v2) ================= */
+.edu {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+  margin-top: clamp(1.25rem, 1rem + 1.5vw, 2rem);
+  border-bottom: none;
+  justify-content: initial;
+  align-items: stretch;
+  padding-bottom: 0;
+}
+.edu__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.1rem 1.25rem;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(4px);
+}
+.edu__degree { font-weight: 600; font-size: var(--text-base); }
+.edu__school { color: var(--text-muted); font-size: var(--text-sm); }
+.edu__period {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+  margin-top: 0.2rem;
+}
+.creds {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem 2.5rem;
+  margin-top: 2rem;
+}
+@media (min-width: 760px) {
+  .creds { grid-template-columns: 1.4fr 1fr; }
+}
+.creds__title {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-subtle);
+  margin-bottom: 0.9rem;
+}
+.creds__list { list-style: none; display: flex; flex-direction: column; gap: 0.7rem; }
+.cert {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding-left: 1rem;
+  position: relative;
+}
+.cert::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.45em;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+.cert__name { font-size: var(--text-sm); font-weight: 500; }
+.cert__issuer { font-size: var(--text-xs); color: var(--text-subtle); }
+.hlang__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.3rem;
+}
+.hlang__name { font-weight: 500; font-size: var(--text-sm); }
+.hlang__level { font-size: var(--text-xs); color: var(--text-subtle); }
+.hlang__bar {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.hlang__fill {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--accent), color-mix(in srgb, var(--accent) 55%, #16a34a));
+}
+
+/* ================= Scroll minimap ================= */
+.minimap {
+  position: fixed;
+  top: 50%;
+  right: clamp(0.75rem, 1.5vw, 2rem);
+  transform: translateY(-50%);
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s var(--ease);
+}
+.minimap.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.minimap__cap {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--text-subtle);
+  letter-spacing: 0.05em;
+}
+.minimap__rail {
+  position: relative;
+  width: 2px;
+  height: min(46vh, 360px);
+  background: var(--border);
+  border-radius: 2px;
+}
+.minimap__fill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: linear-gradient(var(--accent), color-mix(in srgb, var(--accent) 40%, transparent));
+  border-radius: 2px;
+}
+.minimap__thumb {
+  position: absolute;
+  left: 50%;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+  transform: translate(-50%, -50%);
+}
+.minimap__node {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+}
+.minimap__node-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 1.5px solid var(--border-strong);
+  transition: background 0.2s var(--ease), border-color 0.2s var(--ease);
+}
+.minimap__node.is-reached .minimap__node-dot {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.minimap__node-label {
+  position: absolute;
+  right: 16px;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--text-subtle);
+  opacity: 0;
+  transform: translateX(6px);
+  transition: opacity 0.2s var(--ease), transform 0.2s var(--ease);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  padding: 0.05rem 0.35rem;
+  border-radius: 4px;
+}
+.minimap__node-label em { color: var(--accent); font-style: normal; }
+.minimap__node:hover .minimap__node-label,
+.minimap__node.is-reached .minimap__node-label {
+  opacity: 1;
+  transform: none;
+}
+@media (max-width: 1200px) {
+  .minimap { display: none; }
+}
+
+/* ================= Nav game link ================= */
+.nav__game {
+  font-family: var(--font-mono);
+  color: var(--accent) !important;
+}
+@media (max-width: 680px) {
+  .nav__game { display: none; }
+}

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -40,11 +40,26 @@
   .footer,
   .hero__actions,
   .hero__eyebrow,
+  .hero__cta,
+  .hero__aside,
+  .hero__stats,
   .stats,
+  .bg,
+  .minimap,
+  .spinner,
   .theme-toggle,
   .role .tags,
+  .exp__stack,
   .project .tags {
     display: none !important;
+  }
+
+  /* The polished CV is generated as a PDF (see src/cv/CvDocument.tsx);
+     this print stylesheet is only a graceful Ctrl+P fallback. */
+  .num {
+    color: #000 !important;
+    background: none !important;
+    font-weight: 700;
   }
 
   /* Everything visible immediately, no motion. */


### PR DESCRIPTION
## Summary

Full rebuild of the single-page portfolio around the complete career history (ABB 2012 → present), plus a set of new interactive features. Merging this to `master` automatically builds and deploys to GitHub Pages via the existing `.github/workflows/deploy.yml` Action.

## Auto-deploy to GitHub Pages

The repo already has a GitHub Actions workflow (`.github/workflows/deploy.yml`) that, on every push to `master`:
1. Checks out the repo and sets up Bun
2. `bun install --frozen-lockfile` + `bun run build`
3. Uploads `dist/` as a Pages artifact and deploys via `actions/deploy-pages@v4`

Verified that `bun install --frozen-lockfile` passes with the updated `bun.lock`, so CI won't break on the new `@react-pdf/renderer` dependency. No workflow changes were required — merging this PR triggers the existing auto-deploy.

> One-time prerequisite (if not already set): **Settings → Pages → Source = "GitHub Actions"**.

## Content

- Expand `src/data/cv.ts` to the full, unredacted history: **8 roles** with all bullets, **9 domains**, programming-language usage spans, **12 skill groups**, **6 projects**, education, **8 certifications** and spoken languages.
- Drop "Senior" from the headline title; **remove the phone number** everywhere.
- Enrich the hero stat strip with smarter, content-rich figures.

## Features

- **DomainSpinner** — a 3-D cylindrical picker wheel; selecting a domain (Crypto, Payments, Betting, SaaS, Cloud Content, GovTech, Logistics, Game Dev, Everything) re-frames the main description and highlights/dims matching roles.
- **ExperienceCounter** — a styled, self-updating years-of-experience panel calculated from 20 Jun 2012.
- **LanguageTimeline** — colour-coded horizontal bars showing which languages were used when (2012–2026).
- **ScrollMinimap** — right-hand rail showing progress through the experience history, with a node per role.
- **AnimatedBackground** — section-aware colour + pattern shifts via IntersectionObserver (respects reduced-motion).
- Highlight numbers/achievements in experience; animated hover on bullets.
- Expanded, visually grouped technical skills; education + certifications retained at the end.

## Download CV

- Replace `window.print()` with a **deterministic, polished PDF** generated in-browser via `@react-pdf/renderer` (no Chrome "Print to PDF"). Renders a single A4 page focused on the latest/relevant experience. Code-split (`splitting: true`) and **lazy-loaded on click** so the heavy renderer stays out of the initial bundle.

## Projects & game

- Add **Charlie-seven** (Dec 2025 drawing game), **Triven/Skynda**, and more to Selected Projects.
- Refresh the gamified site copy (current crypto/payments roles) and add new pixel-art SVG assets.

## Verification

- `tsc --noEmit` clean
- `bun run build` succeeds; entry bundle ~420 KB, PDF renderer in a separate lazy chunk
- PDF renders as a valid 1-page document
- Headless DOM checks confirmed all sections render with **no console errors**

https://claude.ai/code/session_01H75xQUepTQWKTF513PPyLc

---
_Generated by [Claude Code](https://claude.ai/code/session_01H75xQUepTQWKTF513PPyLc)_