### PR TITLE
Fix CV PDF: name no longer overlaps the subtitle

### DIFF
--- a/src/cv/CvDocument.tsx
+++ b/src/cv/CvDocument.tsx
@@ -39,8 +39,8 @@ const s = StyleSheet.create({
     color: INK,
     lineHeight: 1.4,
   },
-  name: { fontSize: 22, fontFamily: "Helvetica-Bold", letterSpacing: -0.5 },
-  title: { fontSize: 11, color: ACCENT, fontFamily: "Helvetica-Bold", marginTop: 2 },
+  name: { fontSize: 22, fontFamily: "Helvetica-Bold", letterSpacing: -0.5, lineHeight: 1.1 },
+  title: { fontSize: 11, color: ACCENT, fontFamily: "Helvetica-Bold", marginTop: 4, lineHeight: 1.2 },
   contact: { fontSize: 8.5, color: MUTE, marginTop: 4 },
   summary: { marginTop: 8, color: "#333", fontSize: 9 },
   sectionTitle: {


### PR DESCRIPTION
## Summary

The generated CV PDF rendered the name **"Jevgeni Rumjantsev"** overlapping the orange subtitle ("Software Engineer · Payments · Crypto · Distributed Systems").

## Cause

At 22pt the `name` style had no explicit `lineHeight`, so its line box collapsed and the subtitle rendered up over the name's descenders.

## Fix

In `src/cv/CvDocument.tsx`:
- `name`: add `lineHeight: 1.1`
- `title`: bump `marginTop` 2 → 4 and add `lineHeight: 1.2`

Two-line change, no behavioural impact beyond the header spacing.

## Verification

- Regenerated the PDF and rendered it to an image — the name now sits cleanly above the subtitle with no overlap, and the CV still fits on one A4 page.
- `tsc --noEmit` clean; `bun install --frozen-lockfile` passes.

https://claude.ai/code/session_01H75xQUepTQWKTF513PPyLc

---
_Generated by [Claude Code](https://claude.ai/code/session_01H75xQUepTQWKTF513PPyLc)_