### PR TITLE
Add ATS-friendly CV variant

### DIFF
--- a/src/components/DownloadCV.tsx
+++ b/src/components/DownloadCV.tsx
@@ -1,45 +1,111 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+type Variant = "designed" | "ats";
+type Status = "idle" | "working" | "error";
 
 /**
- * Generates a polished, deterministic PDF on the client via @react-pdf/renderer
- * (lazy-loaded) and downloads it. No Chrome "Print to PDF".
+ * Downloads a deterministic, client-generated PDF (via @react-pdf/renderer,
+ * lazy-loaded — no Chrome "Print to PDF"). Offers two variants:
+ *
+ *  - "designed" — the polished, one-page, visually-styled CV.
+ *  - "ats"      — a single-column, keyword-rich CV tuned to pass Applicant
+ *                 Tracking Systems / AI résumé filters.
  */
 export function DownloadCV() {
-  const [state, setState] = useState<"idle" | "working" | "error">("idle");
+  const [status, setStatus] = useState<Status>("idle");
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
 
-  const onClick = async () => {
-    if (state === "working") return;
-    setState("working");
+  // Close the menu on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const download = async (variant: Variant) => {
+    if (status === "working") return;
+    setOpen(false);
+    setStatus("working");
     try {
-      const { buildCvBlob } = await import("../cv/CvDocument.tsx");
-      const blob = await buildCvBlob();
+      const [blob, filename] =
+        variant === "ats"
+          ? [
+              await (await import("../cv/AtsCvDocument.tsx")).buildAtsCvBlob(),
+              "Jevgeni_Rumjantsev_CV_ATS.pdf",
+            ]
+          : [
+              await (await import("../cv/CvDocument.tsx")).buildCvBlob(),
+              "Jevgeni_Rumjantsev_CV.pdf",
+            ];
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = "Jevgeni_Rumjantsev_CV.pdf";
+      a.download = filename;
       document.body.appendChild(a);
       a.click();
       a.remove();
       setTimeout(() => URL.revokeObjectURL(url), 4000);
-      setState("idle");
+      setStatus("idle");
     } catch (err) {
       console.error("CV generation failed", err);
-      setState("error");
+      setStatus("error");
     }
   };
 
+  const label =
+    status === "working"
+      ? "Building PDF…"
+      : status === "error"
+        ? "Retry — Download CV"
+        : "Download CV";
+
   return (
-    <button
-      type="button"
-      className="btn btn--primary"
-      onClick={onClick}
-      disabled={state === "working"}
-    >
-      {state === "working"
-        ? "Building PDF…"
-        : state === "error"
-          ? "Retry download"
-          : "Download CV"}
-    </button>
+    <div className="dlcv" ref={wrapRef}>
+      <button
+        type="button"
+        className="btn btn--primary dlcv__main"
+        onClick={() => setOpen((o) => !o)}
+        disabled={status === "working"}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        {label}
+        <span className="dlcv__caret" aria-hidden="true">▾</span>
+      </button>
+
+      {open && (
+        <div className="dlcv__menu" role="menu">
+          <button
+            type="button"
+            className="dlcv__item"
+            role="menuitem"
+            onClick={() => download("designed")}
+          >
+            <span className="dlcv__item-title">Designed CV</span>
+            <span className="dlcv__item-sub">One page · polished layout</span>
+          </button>
+          <button
+            type="button"
+            className="dlcv__item"
+            role="menuitem"
+            onClick={() => download("ats")}
+          >
+            <span className="dlcv__item-title">ATS-friendly CV</span>
+            <span className="dlcv__item-sub">Keyword-rich · plain · passes filters</span>
+          </button>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/cv/AtsCvDocument.tsx
+++ b/src/cv/AtsCvDocument.tsx
@@ -1,0 +1,241 @@
+/**
+ * ATS-friendly CV rendered with @react-pdf/renderer.
+ *
+ * Unlike CvDocument (the polished, one-page, visually-designed version), this
+ * variant is optimised to pass through Applicant Tracking Systems and keyword
+ * filters:
+ *
+ *  - Single column, top-to-bottom flow (multi-column layouts get scrambled by
+ *    ATS text extractors).
+ *  - Standard, unambiguous section headings ("Professional Experience",
+ *    "Technical Skills", "Education", "Certifications").
+ *  - Plain black text on white, built-in Helvetica only — real selectable text,
+ *    no images, no icons, no decorative glyphs that break parsing.
+ *  - Full keyword coverage: every role, every bullet, every skill group, plus a
+ *    dedicated "Core Competencies" keyword line. Acronyms are spelled out.
+ *  - May run to two pages — ATS does not penalise length; coverage wins.
+ *
+ * Tailor per application by editing src/data/cv.ts (or the ATS_KEYWORDS list
+ * below) so the wording mirrors the specific job description.
+ */
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  StyleSheet,
+  Link,
+  pdf,
+} from "@react-pdf/renderer";
+import {
+  profile,
+  experience,
+  skills,
+  projects,
+  education,
+  certifications,
+  humanLanguages,
+} from "../data/cv.ts";
+
+const INK = "#000000";
+
+const s = StyleSheet.create({
+  page: {
+    paddingTop: 34,
+    paddingBottom: 34,
+    paddingHorizontal: 44,
+    fontFamily: "Helvetica",
+    fontSize: 9,
+    color: INK,
+    lineHeight: 1.25,
+  },
+  name: { fontSize: 17, fontFamily: "Helvetica-Bold", lineHeight: 1.15 },
+  title: { fontSize: 10.5, fontFamily: "Helvetica-Bold", marginTop: 3, lineHeight: 1.2 },
+  contact: { fontSize: 9, marginTop: 3, lineHeight: 1.3 },
+  summaryLabel: { fontFamily: "Helvetica-Bold" },
+  summary: { marginTop: 6, fontSize: 9 },
+
+  sectionTitle: {
+    fontSize: 10.5,
+    fontFamily: "Helvetica-Bold",
+    marginTop: 11,
+    marginBottom: 3,
+    paddingBottom: 2,
+    borderBottomWidth: 1,
+    borderBottomColor: INK,
+  },
+
+  role: { marginTop: 6 },
+  roleHead: { flexDirection: "row", justifyContent: "space-between" },
+  roleTitle: { fontFamily: "Helvetica-Bold", fontSize: 10 },
+  period: { fontSize: 9 },
+  roleMeta: { fontSize: 9, marginBottom: 1 },
+
+  bullet: { flexDirection: "row", marginTop: 1 },
+  dash: { width: 9, fontSize: 9 },
+  bulletText: { flex: 1, fontSize: 9 },
+
+  para: { fontSize: 9, marginTop: 2 },
+  skillLine: { fontSize: 9, marginTop: 1.5 },
+  label: { fontFamily: "Helvetica-Bold" },
+  eduItem: { marginTop: 3 },
+  eduDegree: { fontFamily: "Helvetica-Bold", fontSize: 9.5 },
+  eduMeta: { fontSize: 9 },
+});
+
+/**
+ * A flat keyword line that mirrors the language recruiters and ATS scans look
+ * for. Spell out acronyms both ways so a match fires either form. Tailor this
+ * per application to echo the exact job description.
+ */
+const ATS_KEYWORDS = [
+  "Software Engineer",
+  "Backend Engineer",
+  "Full-Stack Engineer",
+  "Distributed Systems",
+  "Microservices",
+  "Event-Driven Architecture",
+  "Event Sourcing",
+  "CQRS",
+  "Domain-Driven Design (DDD)",
+  "Multi-Tenant SaaS",
+  "Scalability",
+  "High Availability",
+  "Fault Tolerance",
+  "REST APIs",
+  "Message Queues",
+  "Payment Systems",
+  "Fintech",
+  "SEPA",
+  "Strong Customer Authentication (SCA)",
+  "3-D Secure",
+  "Confirmation of Payee (CoP)",
+  "PCI DSS",
+  "Cloud (GCP, Azure)",
+  "Kubernetes",
+  "Docker",
+  "Infrastructure as Code (IaC)",
+  "Terraform",
+  "CI/CD",
+  "Observability",
+  "On-Call",
+  "Agile / Scrum",
+  "Team Leadership",
+];
+
+function AtsCvDocument() {
+  return (
+    <Document
+      title={`${profile.name} — CV (ATS)`}
+      author={profile.name}
+      subject="Curriculum Vitae"
+      keywords={ATS_KEYWORDS.join(", ")}
+    >
+      <Page size="A4" style={s.page}>
+        {/* Header */}
+        <Text style={s.name}>{profile.name}</Text>
+        <Text style={s.title}>
+          {profile.title} — {profile.tagline}
+        </Text>
+        <Text style={s.contact}>
+          {profile.location} | {profile.email} |{" "}
+          <Link src={profile.linkedinUrl}>{profile.linkedin}</Link> |{" "}
+          <Link src={profile.githubUrl}>{profile.github}</Link>
+        </Text>
+
+        {/* Summary */}
+        <Text style={s.sectionTitle}>Professional Summary</Text>
+        <Text style={s.summary}>{profile.summary}</Text>
+
+        {/* Core competencies / keyword line */}
+        <Text style={s.sectionTitle}>Core Competencies</Text>
+        <Text style={s.para}>{ATS_KEYWORDS.join(" • ")}</Text>
+
+        {/* Experience — every role, every bullet */}
+        <Text style={s.sectionTitle}>Professional Experience</Text>
+        {experience.map((role) => (
+          <View key={role.company} style={s.role} wrap={false}>
+            <View style={s.roleHead}>
+              <Text style={s.roleTitle}>
+                {role.role}, {role.company}
+              </Text>
+              <Text style={s.period}>{role.period}</Text>
+            </View>
+            <Text style={s.roleMeta}>
+              {role.companyNote ? `${role.companyNote} — ` : ""}
+              {role.location}
+            </Text>
+            {role.highlights.map((h) => (
+              <View key={h} style={s.bullet}>
+                <Text style={s.dash}>-</Text>
+                <Text style={s.bulletText}>{h}</Text>
+              </View>
+            ))}
+            {role.stack && role.stack.length > 0 && (
+              <Text style={s.skillLine}>
+                <Text style={s.label}>Technologies: </Text>
+                {role.stack.join(", ")}
+              </Text>
+            )}
+          </View>
+        ))}
+
+        {/* Skills — full list, all groups */}
+        <Text style={s.sectionTitle}>Technical Skills</Text>
+        {skills.map((g) => (
+          <Text key={g.label} style={s.skillLine}>
+            <Text style={s.label}>{g.label}: </Text>
+            {g.items.join(", ")}
+          </Text>
+        ))}
+
+        {/* Selected projects */}
+        <Text style={s.sectionTitle}>Selected Projects</Text>
+        {projects.map((p) => (
+          <View key={p.name} style={s.bullet}>
+            <Text style={s.dash}>-</Text>
+            <Text style={s.bulletText}>
+              <Text style={s.label}>{p.name}{p.year ? ` (${p.year})` : ""}: </Text>
+              {p.description} [{p.tags.join(", ")}]
+            </Text>
+          </View>
+        ))}
+
+        {/* Education */}
+        <Text style={s.sectionTitle}>Education</Text>
+        {education.map((e) => (
+          <View key={e.degree} style={s.eduItem}>
+            <Text style={s.eduDegree}>{e.degree}</Text>
+            <Text style={s.eduMeta}>
+              {e.school} | {e.period}
+              {e.note ? ` | ${e.note}` : ""}
+            </Text>
+          </View>
+        ))}
+
+        {/* Certifications */}
+        <Text style={s.sectionTitle}>Certifications</Text>
+        {certifications.map((c) => (
+          <View key={c.name} style={s.bullet}>
+            <Text style={s.dash}>-</Text>
+            <Text style={s.bulletText}>
+              {c.name} — {c.issuer}
+              {c.year ? ` (${c.year})` : ""}
+            </Text>
+          </View>
+        ))}
+
+        {/* Languages */}
+        <Text style={s.sectionTitle}>Languages</Text>
+        <Text style={s.para}>
+          {humanLanguages.map((l) => `${l.language} (${l.level})`).join(", ")}
+        </Text>
+      </Page>
+    </Document>
+  );
+}
+
+/** Builds the ATS-friendly CV as a Blob — deterministic, no Chrome involved. */
+export async function buildAtsCvBlob(): Promise<Blob> {
+  return pdf(<AtsCvDocument />).toBlob();
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1434,3 +1434,64 @@ main {
 @media (max-width: 680px) {
   .nav__game { display: none; }
 }
+
+/* ================= Download-CV split button + menu ================= */
+.dlcv {
+  position: relative;
+  display: inline-block;
+}
+.dlcv__main {
+  gap: 0.45rem;
+}
+.dlcv__caret {
+  font-size: 0.7em;
+  opacity: 0.85;
+}
+.dlcv__menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  z-index: 60;
+  min-width: 230px;
+  display: flex;
+  flex-direction: column;
+  padding: 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+  animation: dlcvIn 0.16s var(--ease);
+}
+@keyframes dlcvIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dlcv__menu { animation: none; }
+}
+.dlcv__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  text-align: left;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0.5rem 0.6rem;
+  border-radius: 6px;
+  color: var(--text);
+  font: inherit;
+  transition: background 0.15s var(--ease);
+}
+.dlcv__item:hover,
+.dlcv__item:focus-visible {
+  background: var(--accent-soft);
+}
+.dlcv__item-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+.dlcv__item-sub {
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+}


### PR DESCRIPTION
## Why

Recruiters' **Applicant Tracking Systems (ATS)** and AI résumé filters parse a CV *before* a human sees it, and rank/reject based on keyword coverage and how cleanly the document parses. The existing polished one-page CV is great for humans, but its compact, multi-column-ish, glyph-decorated layout is exactly what ATS text extractors handle poorly — and it trims content to fit one page, which costs keyword coverage.

## What

Add a **second CV variant** (`src/cv/AtsCvDocument.tsx`) optimised to pass ATS:

- **Single column, top-to-bottom flow** — multi-column layouts get scrambled by ATS extractors.
- **Standard, unambiguous headings** — Professional Summary, Core Competencies, Professional Experience, Technical Skills, Selected Projects, Education, Certifications, Languages.
- **Plain black text, built-in Helvetica, real selectable text** — no icons, no decorative glyphs, no images.
- **Full keyword coverage** — every role with all bullets, every skill group, all projects and certifications, plus a dedicated **Core Competencies** line. Acronyms are spelled out both ways (e.g. *Strong Customer Authentication (SCA)*, *Confirmation of Payee (CoP)*).
- **PDF `keywords` metadata** set from the same list.
- Runs to ~3 pages by design — ATS doesn't penalise length; coverage wins.

The **Download CV** button becomes a split button offering **Designed CV** and **ATS-friendly CV**. Both PDFs are still generated deterministically client-side via `@react-pdf/renderer` (no Chrome "Print to PDF"), and each is code-split into a tiny lazy chunk (~5 KB) — the shared 2.1 MB renderer loads only on first download.

## Tailoring per application

Your friend's advice ("adjust the CV to every application to contain all the keywords") is built in: edit the `ATS_KEYWORDS` list in `AtsCvDocument.tsx` (or the underlying `src/data/cv.ts`) to mirror the exact wording of a given job description. Only claim what's true — this emphasises real experience in the posting's vocabulary, it doesn't invent skills.

## Verification

- `tsc --noEmit` clean; `bun run build` succeeds.
- Rendered both PDFs to images: ATS variant is a clean 3-page single-column document; designed variant unchanged.
- Chunk sizes confirmed: entry ~383 KB, each CV variant ~5 KB, shared renderer lazy-loaded.
- `bun install --frozen-lockfile` passes (no dependency changes).

> Note: this branch is independent of the CV header-overlap fix PR — that fix touches the designed CV only and can merge in either order.

https://claude.ai/code/session_01H75xQUepTQWKTF513PPyLc

---
_Generated by [Claude Code](https://claude.ai/code/session_01H75xQUepTQWKTF513PPyLc)_