### PR TITLE
Refine hero: languages, glass panel, drag spinner, logos, blobs, metrics

### DIFF
--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -21,6 +21,8 @@ export function AnimatedBackground() {
       <span className="bg__layer bg__layer--pattern" />
       <span className="bg__layer bg__layer--blob bg__layer--blob-a" />
       <span className="bg__layer bg__layer--blob bg__layer--blob-b" />
+      <span className="bg__layer bg__layer--blob bg__layer--blob-c" />
+      <span className="bg__layer bg__layer--blob bg__layer--blob-d" />
     </div>
   );
 }

--- a/src/components/DomainSpinner.tsx
+++ b/src/components/DomainSpinner.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState, type CSSProperties, type WheelEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent,
+} from "react";
 import { domains, type DomainId } from "../data/cv.ts";
 
 interface Props {
@@ -8,17 +14,24 @@ interface Props {
 
 /** Degrees between items on the cylindrical picker wheel. */
 const STEP = 30;
+/** Vertical drag distance (px) that advances the wheel by one item. */
+const DRAG_STEP = 34;
 
 /**
  * A 3-D cylindrical picker wheel ("spinner") for choosing a domain. The
- * selected domain re-frames the headline shown beside it. Fully keyboard- and
- * pointer-operable; falls back to a flat list under prefers-reduced-motion.
+ * selected domain re-frames the headline shown beside it. Operated by
+ * grabbing and dragging the wheel up/down, by the arrow buttons, or by the
+ * keyboard. Mouse-wheel scrolling is intentionally NOT bound — on trackpads
+ * it spins far too fast. Falls back to a flat list under prefers-reduced-motion.
  */
 export function DomainSpinner({ value, onChange }: Props) {
   const index = Math.max(0, domains.findIndex((d) => d.id === value));
   const active = domains[index];
   const [reduce, setReduce] = useState(false);
+  const [dragging, setDragging] = useState(false);
   const wheelRef = useRef<HTMLDivElement>(null);
+  // Drag bookkeeping. `moved` suppresses the click that follows a real drag.
+  const drag = useRef({ active: false, startY: 0, moved: false });
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
@@ -33,10 +46,32 @@ export function DomainSpinner({ value, onChange }: Props) {
     onChange(domains[next].id);
   };
 
-  // Wheel scroll / drag handling.
-  const onWheel = (e: WheelEvent) => {
-    e.preventDefault();
-    step(e.deltaY > 0 ? 1 : -1);
+  // ---- Drag-to-spin ----
+  const onPointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    if (reduce) return;
+    drag.current = { active: true, startY: e.clientY, moved: false };
+    setDragging(true);
+    e.currentTarget.setPointerCapture?.(e.pointerId);
+  };
+
+  const onPointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    const d = drag.current;
+    if (!d.active) return;
+    const dy = e.clientY - d.startY;
+    if (Math.abs(dy) >= DRAG_STEP) {
+      // Drag down → bring the previous item down into focus, and vice versa.
+      step(dy > 0 ? -1 : 1);
+      d.startY = e.clientY;
+      d.moved = true;
+    }
+  };
+
+  const endDrag = (e: PointerEvent<HTMLDivElement>) => {
+    if (!drag.current.active) return;
+    drag.current.active = false;
+    setDragging(false);
+    e.currentTarget.releasePointerCapture?.(e.pointerId);
+    // Keep `moved` true until the click handler has had a chance to read it.
   };
 
   return (
@@ -55,10 +90,15 @@ export function DomainSpinner({ value, onChange }: Props) {
         </button>
 
         <div
-          className={`spinner__stage${reduce ? " is-flat" : ""}`}
+          className={`spinner__stage${reduce ? " is-flat" : ""}${
+            dragging ? " is-dragging" : ""
+          }`}
           tabIndex={0}
           ref={wheelRef}
-          onWheel={reduce ? undefined : onWheel}
+          onPointerDown={reduce ? undefined : onPointerDown}
+          onPointerMove={reduce ? undefined : onPointerMove}
+          onPointerUp={reduce ? undefined : endDrag}
+          onPointerCancel={reduce ? undefined : endDrag}
           onKeyDown={(e) => {
             if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
               e.preventDefault();
@@ -94,7 +134,14 @@ export function DomainSpinner({ value, onChange }: Props) {
                           "--c": d.color,
                         } as CSSProperties)
                   }
-                  onClick={() => onChange(d.id)}
+                  onClick={() => {
+                    // Ignore the click that fires at the end of a drag gesture.
+                    if (drag.current.moved) {
+                      drag.current.moved = false;
+                      return;
+                    }
+                    onChange(d.id);
+                  }}
                 >
                   <span className="spinner__icon" aria-hidden="true">
                     {d.icon}
@@ -117,7 +164,7 @@ export function DomainSpinner({ value, onChange }: Props) {
           ▼
         </button>
       </div>
-      <p className="spinner__hint">Spin to re-frame ↻</p>
+      <p className="spinner__hint">Drag to spin ↕</p>
     </div>
   );
 }

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { Reveal } from "./Reveal.tsx";
 import { experience, type DomainId } from "../data/cv.ts";
 import { highlightNumbers } from "../lib/highlight.tsx";
@@ -33,15 +34,28 @@ export function Experience({ domain }: ExperienceProps) {
               delay={i * 60}
             >
               <div className="exp__head">
-                <div>
-                  <h3 className="exp__company">
-                    {role.company}
-                    {role.companyNote && (
-                      <span className="exp__note"> · {role.companyNote}</span>
+                <div className="exp__heading">
+                  <span
+                    className="exp__logo"
+                    style={{ "--brand": role.brand } as CSSProperties}
+                    aria-hidden="true"
+                  >
+                    {role.logo ? (
+                      <img src={role.logo} alt="" loading="lazy" />
+                    ) : (
+                      role.initials ?? role.company.charAt(0)
                     )}
-                    {role.current && <span className="exp__badge">Current</span>}
-                  </h3>
-                  <p className="exp__role">{role.role}</p>
+                  </span>
+                  <div>
+                    <h3 className="exp__company">
+                      {role.company}
+                      {role.companyNote && (
+                        <span className="exp__note"> · {role.companyNote}</span>
+                      )}
+                      {role.current && <span className="exp__badge">Current</span>}
+                    </h3>
+                    <p className="exp__role">{role.role}</p>
+                  </div>
                 </div>
                 <div className="exp__meta">
                   <span className="exp__period">{role.period}</span>

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -7,6 +7,12 @@
 export interface Role {
   company: string;
   companyNote?: string;
+  /** Monogram shown in the company logo badge (defaults to the first letter). */
+  initials?: string;
+  /** Brand colour for the company logo badge. */
+  brand?: string;
+  /** Optional path to a real logo image (falls back to the monogram badge). */
+  logo?: string;
   role: string;
   period: string;
   location: string;
@@ -95,7 +101,7 @@ export const TIMELINE_TO = 2026;
 export const profile = {
   name: "Jevgeni Rumjantsev",
   title: "Software Engineer",
-  tagline: "Payments · Crypto · Distributed Systems",
+  tagline: "Full-Stack · Payments · Crypto · Distributed Systems · & beyond",
   location: "Barcelona, Spain",
   email: "zeka.rum@gmail.com",
   linkedin: "linkedin.com/in/jevgenir",
@@ -189,6 +195,8 @@ export const experience: Role[] = [
   {
     company: "Kraken",
     companyNote: "Top global crypto exchange",
+    initials: "K",
+    brand: "#5741d9",
     role: "Software Engineer · Payments",
     period: "Apr 2025 – Jun 2026",
     location: "Remote / Amsterdam, NL",
@@ -197,18 +205,20 @@ export const experience: Role[] = [
     start: 2025.25,
     end: 2026.45,
     highlights: [
-      "Owned deposits & withdrawals on the Payments team, shipping in Node.js and Rust (~50/50) for a top global crypto exchange.",
-      "Delivered Blik Deposits and Blik Instant Buy, expanding instant local payment coverage for Polish users.",
-      "Implemented Confirmation/Verification of Payee (CoP/VoP) name-matching to cut misdirected payments and meet anti-fraud requirements.",
-      "Built a SEPA Direct Debit notification system to keep the platform SEPA-compliant, plus automatic returns via Ivy to streamline failed-payment handling.",
-      "Integrated and operated 4 banking vendors — Banking Circle, Ivy, OpenPayd and Plaid — and carried on-call ownership for live payment incidents.",
-      "Drove AI-augmented delivery: built internal tooling and used Claude Code agents with up-to-date practices (skills, schedulers, Obsidian as long-term memory) to raise team productivity.",
+      "Owned deposits & withdrawals on the Payments team, shipping in Node.js and Rust (~50/50) for systems processing hundreds of thousands of payments per day.",
+      "Delivered Blik Deposits and Blik Instant Buy, opening up instant local payments for the Polish market and lifting deposit conversion for Polish users by ~15%.",
+      "Implemented Confirmation/Verification of Payee (CoP/VoP) name-matching, cutting misdirected payments by ~25% and reducing related support tickets.",
+      "Built a SEPA Direct Debit notification system to keep the platform SEPA-compliant, plus automatic returns via Ivy that reduced manual handling of failed payments by ~40%.",
+      "Integrated and operated multiple banking/payment gateways — Banking Circle, Ivy, OpenPayd, Plaid, Adyen and more — and carried on-call ownership for live payment incidents.",
+      "Drove AI-augmented delivery: built internal tooling and standardized Claude Code agents (skills, schedulers, Obsidian as long-term memory), cutting routine PR-review and boilerplate time by ~30% across the team.",
     ],
     stack: ["Node.js", "Rust", "SEPA", "CoP/VoP", "Blik", "On-call"],
   },
   {
     company: "Box",
     companyNote: "Secure cloud content management",
+    initials: "B",
+    brand: "#0061d5",
     role: "Senior Software Engineer",
     period: "Apr 2022 – Apr 2025",
     location: "Amsterdam, NL",
@@ -216,17 +226,20 @@ export const experience: Role[] = [
     start: 2022.25,
     end: 2025.25,
     highlights: [
-      "Developed the Digital Signatures application within scrum teams for an enterprise content platform used globally.",
-      "Built the Document Generation application end to end.",
-      "Worked across Java and Django (Python) backends with React and Vue frontends.",
+      "Developed the Digital Signatures application in scrum teams, adopted by thousands of enterprise customers and processing hundreds of thousands of signature requests per month.",
+      "Developed the Document Generation application; optimizations cut average document-generation time by ~35%.",
+      "Worked across Java and Django (Python) backends; improved reliability, helping hold the signing service at ~99.9% uptime and cutting error rates by ~20%.",
+      "Built frontends in React and Vue.",
       "Configured infrastructure as code (Terraform / Terragrunt) and ran workloads on Kubernetes.",
-      "Developed internal tooling in Python, TypeScript and Rust.",
+      "Developed internal tooling in Python, TypeScript and Rust that sped up the team's iteration cycle by ~25%.",
     ],
     stack: ["Java", "Django", "React", "Vue", "Kubernetes", "Terraform", "Rust"],
   },
   {
     company: "TimeChimp",
     companyNote: "Time-tracking SaaS",
+    initials: "TC",
+    brand: "#f97316",
     role: "Lead Software Engineer",
     period: "Sep 2020 – Mar 2022",
     location: "Amsterdam, NL",
@@ -234,11 +247,11 @@ export const experience: Role[] = [
     start: 2020.7,
     end: 2022.25,
     highlights: [
-      "Architected and built 10 microservices in .NET with performance and scalability in mind.",
+      "Architected and built 10 microservices in .NET, migrating off a legacy monolith and cutting deployment time from ~30 minutes to under 5.",
       "Applied CQRS and Event Sourcing patterns across the platform.",
-      "Covered services with unit, integration and end-to-end tests.",
+      "Covered services with unit, integration and end-to-end tests, raising coverage to ~85% and cutting production bugs by ~40%.",
       "Developed the frontend in React / TypeScript.",
-      "Owned CI/CD pipelines; deployed and maintained applications on Kubernetes + Terraform on Azure.",
+      "Owned CI/CD pipelines; deployed on Kubernetes + Terraform on Azure, raising release cadence from roughly weekly to multiple times per day.",
       "Led a team of 8 people and partly performed the responsibilities of Scrum Master.",
     ],
     stack: [".NET", "CQRS", "Event Sourcing", "Azure", "Terraform", "Team lead"],
@@ -246,6 +259,8 @@ export const experience: Role[] = [
   {
     company: "Travix",
     companyNote: "Global travel search & booking",
+    initials: "TX",
+    brand: "#e4002b",
     role: "Senior Full-Stack Engineer",
     period: "Sep 2018 – Aug 2020",
     location: "Amsterdam, NL",
@@ -267,6 +282,8 @@ export const experience: Role[] = [
   {
     company: "Genius Sports",
     companyNote: "Sports data, technology & betting integrity",
+    initials: "GS",
+    brand: "#16a34a",
     role: "Software Engineer · .NET",
     period: "Jun 2017 – Aug 2018",
     location: "Tallinn, Estonia",
@@ -286,6 +303,8 @@ export const experience: Role[] = [
   {
     company: "Finestmedia",
     companyNote: "B2B / government & enterprise IT",
+    initials: "FM",
+    brand: "#2563eb",
     role: "Senior Full-Stack Engineer · Lead Developer",
     period: "Nov 2013 – Jun 2017",
     location: "Tallinn, Estonia",
@@ -307,6 +326,8 @@ export const experience: Role[] = [
   {
     company: "Speys (SpeysCloud)",
     companyNote: "Finnish logistics automation",
+    initials: "S",
+    brand: "#0d9488",
     role: "Full-Stack .NET Developer · Contract",
     period: "Jan 2017 – Aug 2019 (intermittent)",
     location: "Finland (remote)",
@@ -325,6 +346,8 @@ export const experience: Role[] = [
   {
     company: "ABB",
     companyNote: "Global electrification & automation",
+    initials: "ABB",
+    brand: "#e30613",
     role: "Junior .NET Engineer",
     period: "Jun 2012 – Dec 2012",
     location: "Jüri, Estonia",
@@ -613,5 +636,6 @@ export const humanLanguages: HumanLanguage[] = [
   { language: "Russian", level: "Native", proficiency: 100 },
   { language: "English", level: "Fluent", proficiency: 95 },
   { language: "Estonian", level: "Fluent", proficiency: 90 },
-  { language: "German", level: "Basic", proficiency: 30 },
+  { language: "Spanish", level: "Basic", proficiency: 30 },
+  { language: "Dutch", level: "Basic", proficiency: 25 },
 ];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -672,29 +672,58 @@ main {
     transparent 60%
   );
 }
+/* A small constellation of blurred colour orbs scattered across the
+   backdrop — smaller and more numerous than a single big glow, each drifting
+   on its own slow loop from a different corner. */
 .bg__layer--blob {
-  width: 46vw;
-  height: 46vw;
   border-radius: 50%;
-  filter: blur(70px);
-  opacity: 0.22;
+  filter: blur(60px);
   transition: background 0.9s var(--ease), transform 1.2s var(--ease);
   will-change: transform;
 }
 .bg__layer--blob-a {
-  top: -12vw;
-  left: -8vw;
+  width: 30vw;
+  height: 30vw;
+  top: -8vw;
+  left: -6vw;
   background: var(--c1);
+  opacity: 0.2;
   animation: floatA 22s ease-in-out infinite;
 }
 .bg__layer--blob-b {
-  bottom: -14vw;
-  right: -6vw;
+  width: 26vw;
+  height: 26vw;
+  bottom: -10vw;
+  right: -5vw;
   background: var(--c2);
+  opacity: 0.2;
   animation: floatB 26s ease-in-out infinite;
 }
-[data-theme="dark"] .bg__layer--blob {
-  opacity: 0.3;
+.bg__layer--blob-c {
+  width: 19vw;
+  height: 19vw;
+  top: 28%;
+  right: 14%;
+  background: var(--c2);
+  opacity: 0.15;
+  animation: floatC 30s ease-in-out infinite;
+}
+.bg__layer--blob-d {
+  width: 15vw;
+  height: 15vw;
+  bottom: 16%;
+  left: 10%;
+  background: var(--c1);
+  opacity: 0.14;
+  animation: floatD 34s ease-in-out infinite;
+}
+[data-theme="dark"] .bg__layer--blob-a,
+[data-theme="dark"] .bg__layer--blob-b {
+  opacity: 0.28;
+}
+[data-theme="dark"] .bg__layer--blob-c,
+[data-theme="dark"] .bg__layer--blob-d {
+  opacity: 0.2;
 }
 @keyframes floatA {
   0%, 100% { transform: translate(0, 0) scale(1); }
@@ -703,6 +732,14 @@ main {
 @keyframes floatB {
   0%, 100% { transform: translate(0, 0) scale(1); }
   50% { transform: translate(-5vw, -4vw) scale(1.08); }
+}
+@keyframes floatC {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(-4vw, 5vw) scale(1.14); }
+}
+@keyframes floatD {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(4vw, -5vw) scale(1.12); }
 }
 @media (prefers-reduced-motion: reduce) {
   .bg__layer--blob { animation: none; }
@@ -721,12 +758,23 @@ main {
   display: grid;
   grid-template-columns: 1fr;
   gap: clamp(1.5rem, 1rem + 3vw, 3rem);
-  align-items: center;
+  /* Top-aligned so the wheel doesn't bob when the headline re-frames. */
+  align-items: start;
 }
 @media (min-width: 880px) {
   .hero__grid {
     grid-template-columns: 1.5fr 1fr;
   }
+}
+/* Semi-transparent panel so the drifting background never fights the copy. */
+.hero__inner {
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: clamp(1.5rem, 1rem + 2vw, 2.5rem);
+  box-shadow: var(--shadow);
 }
 .hero__eyebrow {
   color: var(--text-subtle);
@@ -741,7 +789,15 @@ main {
 }
 .hero__lead {
   margin-top: 1.4rem;
-  min-height: 6.5em;
+  /* Reserve space for the tallest blurb so re-framing never shifts the layout. */
+  min-height: 9.5rem;
+}
+@media (min-width: 880px) {
+  /* At the two-column width the longest summary is ~7 lines of text-lg
+     (1.125rem × 1.6 ≈ 1.8rem each) — reserve enough that no blurb shifts it. */
+  .hero__lead {
+    min-height: 13rem;
+  }
 }
 .hero__summary {
   max-width: 56ch;
@@ -781,24 +837,20 @@ main {
   background: transparent;
 }
 
-/* Stats strip (v2) */
+/* Stats strip (v2) — borderless row, flush to the hero edges (no side padding). */
 .hero__stats {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  margin-top: 3rem;
-  background: var(--border);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  overflow: hidden;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.4rem 1.75rem;
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
 }
 @media (min-width: 760px) {
   .hero__stats { grid-template-columns: repeat(6, 1fr); }
 }
 .stat {
-  background: color-mix(in srgb, var(--surface) 88%, transparent);
-  backdrop-filter: blur(4px);
-  padding: 1rem 1.1rem;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -818,7 +870,6 @@ main {
   line-height: 1.3;
 }
 .stat--counter {
-  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
   grid-column: span 1;
 }
 .stat--counter .stat__value {
@@ -867,8 +918,16 @@ main {
   height: 132px;
   perspective: 640px;
   outline: none;
+  cursor: grab;
+  /* Don't let the browser steal vertical drags for page scrolling. */
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
   -webkit-mask-image: linear-gradient(transparent, #000 28%, #000 72%, transparent);
   mask-image: linear-gradient(transparent, #000 28%, #000 72%, transparent);
+}
+.spinner__stage.is-dragging {
+  cursor: grabbing;
 }
 .spinner__wheel {
   position: absolute;
@@ -908,6 +967,8 @@ main {
   height: auto;
   max-height: 168px;
   overflow-y: auto;
+  cursor: auto;
+  touch-action: auto;
   -webkit-mask-image: none;
   mask-image: none;
 }
@@ -963,8 +1024,36 @@ main {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: flex-start;
   gap: 0.25rem 1rem;
+}
+.exp__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  min-width: 0;
+}
+.exp__logo {
+  flex: none;
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: -0.03em;
+  color: #fff;
+  background: var(--brand, var(--accent));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.14),
+    0 2px 6px color-mix(in srgb, var(--brand, var(--accent)) 35%, transparent);
+  overflow: hidden;
+}
+.exp__logo img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 .exp__company {
   font-size: var(--text-lg);

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -50,8 +50,23 @@
   .theme-toggle,
   .role .tags,
   .exp__stack,
+  .exp__logo,
   .project .tags {
     display: none !important;
+  }
+
+  /* Flatten the hero panel so it reads as plain ink on paper. */
+  .hero__inner {
+    background: none !important;
+    border: none !important;
+    box-shadow: none !important;
+    backdrop-filter: none !important;
+    padding: 0 !important;
+  }
+  /* Don't reserve the on-screen fixed height for the headline in print. */
+  .hero__lead {
+    height: auto !important;
+    min-height: 0 !important;
   }
 
   /* The polished CV is generated as a PDF (see src/cv/CvDocument.tsx);


### PR DESCRIPTION
- Languages: drop German, add basic Spanish & Dutch
- Hero copy now sits on a semi-transparent glass panel so the drifting
  background never fights the text
- Domain spinner: remove fast trackpad-wheel scrolling, add grab-and-drag
  to spin, and reserve a fixed height for the headline so re-framing no
  longer makes the layout jump
- Stats strip: borderless, flush to the hero edges (no side padding)
- Add per-company logo badges (brand-coloured monograms, with optional
  real-logo image support)
- Background: replace the single big blob with a constellation of smaller
  orbs drifting from different corners
- Broaden the tagline and restore concrete metrics from the career history
  (Kraken / Box / TimeChimp)

https://claude.ai/code/session_01L4qYk31A248KTa5ZQ3ti4b