### PR TITLE
Make Download CV a split button that downloads PDF in one click

### DIFF
--- a/src/components/DownloadCV.tsx
+++ b/src/components/DownloadCV.tsx
@@ -5,11 +5,13 @@ type Status = "idle" | "working" | "error";
 
 /**
  * Downloads a deterministic, client-generated PDF (via @react-pdf/renderer,
- * lazy-loaded — no Chrome "Print to PDF"). Offers two variants:
+ * lazy-loaded — no Chrome "Print to PDF"). Rendered as a split button:
  *
- *  - "designed" — the polished, one-page, visually-styled CV.
- *  - "ats"      — a single-column, keyword-rich CV tuned to pass Applicant
- *                 Tracking Systems / AI résumé filters.
+ *  - The main blue button downloads the "designed" CV in one click — the
+ *    polished, one-page, visually-styled variant — with no extra menu step.
+ *  - The divided caret segment reveals the "ats" variant: a single-column,
+ *    keyword-rich CV tuned to pass Applicant Tracking Systems / AI résumé
+ *    filters (the designed variant is repeated there for completeness).
  */
 export function DownloadCV() {
   const [status, setStatus] = useState<Status>("idle");
@@ -72,17 +74,30 @@ export function DownloadCV() {
 
   return (
     <div className="dlcv" ref={wrapRef}>
-      <button
-        type="button"
-        className="btn btn--primary dlcv__main"
-        onClick={() => setOpen((o) => !o)}
-        disabled={status === "working"}
-        aria-haspopup="menu"
-        aria-expanded={open}
-      >
-        {label}
-        <span className="dlcv__caret" aria-hidden="true">▾</span>
-      </button>
+      <div className="dlcv__split">
+        {/* Primary action: one click downloads the polished PDF — no menu. */}
+        <button
+          type="button"
+          className="btn btn--primary dlcv__main"
+          onClick={() => download("designed")}
+          disabled={status === "working"}
+        >
+          {label}
+        </button>
+        {/* Secondary: an explicit, divided segment for the other format. */}
+        <button
+          type="button"
+          className="btn btn--primary dlcv__toggle"
+          onClick={() => setOpen((o) => !o)}
+          disabled={status === "working"}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label="More CV formats"
+          title="More CV formats"
+        >
+          <span className="dlcv__caret" aria-hidden="true">▾</span>
+        </button>
+      </div>
 
       {open && (
         <div className="dlcv__menu" role="menu">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1065,8 +1065,20 @@ main { display: block; }
 
 /* ============================ Download-CV split button + menu ============================ */
 .dlcv { position: relative; display: inline-block; }
-.dlcv__main { gap: 0.45rem; }
-.dlcv__caret { font-size: 0.7em; opacity: 0.85; }
+/* Split button: solid primary action + a divided caret for other formats. */
+.dlcv__split { display: inline-flex; }
+.dlcv__main {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.dlcv__toggle {
+  padding-inline: 0.7rem;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left-color: color-mix(in srgb, var(--accent-contrast) 35%, transparent);
+  margin-left: -1px;
+}
+.dlcv__caret { font-size: 0.8em; opacity: 0.9; }
 .dlcv__menu {
   position: absolute;
   top: calc(100% + 0.4rem);


### PR DESCRIPTION
Feedback: clicking the blue 'Download CV' button opened a dropdown whose
items were easy to miss (they rendered tucked away on large screens), so
nothing seemed to happen. Restructure into a split button — the main blue
button now downloads the polished PDF immediately, while a clearly divided
caret segment reveals the ATS-friendly format for those who want it.