### PR TITLE
Make Download CV a one-click split button and fix menu clipping

### DIFF
--- a/src/components/DownloadCV.tsx
+++ b/src/components/DownloadCV.tsx
@@ -5,11 +5,13 @@ type Status = "idle" | "working" | "error";
 
 /**
  * Downloads a deterministic, client-generated PDF (via @react-pdf/renderer,
- * lazy-loaded — no Chrome "Print to PDF"). Offers two variants:
+ * lazy-loaded — no Chrome "Print to PDF"). Rendered as a split button:
  *
- *  - "designed" — the polished, one-page, visually-styled CV.
- *  - "ats"      — a single-column, keyword-rich CV tuned to pass Applicant
- *                 Tracking Systems / AI résumé filters.
+ *  - The main blue button downloads the "designed" CV in one click — the
+ *    polished, one-page, visually-styled variant — with no extra menu step.
+ *  - The divided caret segment reveals the "ats" variant: a single-column,
+ *    keyword-rich CV tuned to pass Applicant Tracking Systems / AI résumé
+ *    filters (the designed variant is repeated there for completeness).
  */
 export function DownloadCV() {
   const [status, setStatus] = useState<Status>("idle");
@@ -72,17 +74,30 @@ export function DownloadCV() {
 
   return (
     <div className="dlcv" ref={wrapRef}>
-      <button
-        type="button"
-        className="btn btn--primary dlcv__main"
-        onClick={() => setOpen((o) => !o)}
-        disabled={status === "working"}
-        aria-haspopup="menu"
-        aria-expanded={open}
-      >
-        {label}
-        <span className="dlcv__caret" aria-hidden="true">▾</span>
-      </button>
+      <div className="dlcv__split">
+        {/* Primary action: one click downloads the polished PDF — no menu. */}
+        <button
+          type="button"
+          className="btn btn--primary dlcv__main"
+          onClick={() => download("designed")}
+          disabled={status === "working"}
+        >
+          {label}
+        </button>
+        {/* Secondary: an explicit, divided segment for the other format. */}
+        <button
+          type="button"
+          className="btn btn--primary dlcv__toggle"
+          onClick={() => setOpen((o) => !o)}
+          disabled={status === "working"}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label="More CV formats"
+          title="More CV formats"
+        >
+          <span className="dlcv__caret" aria-hidden="true">▾</span>
+        </button>
+      </div>
 
       {open && (
         <div className="dlcv__menu" role="menu">

--- a/src/components/DownloadCV.tsx
+++ b/src/components/DownloadCV.tsx
@@ -16,11 +16,22 @@ type Status = "idle" | "working" | "error";
 export function DownloadCV() {
   const [status, setStatus] = useState<Status>("idle");
   const [open, setOpen] = useState(false);
+  // The menu is fixed-positioned (anchored to the button via measured coords)
+  // so it can't be clipped by an ancestor's `overflow: hidden` — the hero is a
+  // glass panel that clips its children.
+  const [pos, setPos] = useState<{ top: number; right: number } | null>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
 
-  // Close the menu on outside click / Escape.
+  // Close the menu on outside click / Escape; keep it anchored on scroll/resize.
   useEffect(() => {
     if (!open) return;
+    const place = () => {
+      const el = wrapRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      setPos({ top: r.bottom + 6, right: window.innerWidth - r.right });
+    };
+    place();
     const onDown = (e: MouseEvent) => {
       if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
         setOpen(false);
@@ -29,9 +40,13 @@ export function DownloadCV() {
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
     document.addEventListener("mousedown", onDown);
     document.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", place, true);
+    window.addEventListener("resize", place);
     return () => {
       document.removeEventListener("mousedown", onDown);
       document.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", place, true);
+      window.removeEventListener("resize", place);
     };
   }, [open]);
 
@@ -99,8 +114,12 @@ export function DownloadCV() {
         </button>
       </div>
 
-      {open && (
-        <div className="dlcv__menu" role="menu">
+      {open && pos && (
+        <div
+          className="dlcv__menu"
+          role="menu"
+          style={{ top: pos.top, right: pos.right }}
+        >
           <button
             type="button"
             className="dlcv__item"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1065,8 +1065,20 @@ main { display: block; }
 
 /* ============================ Download-CV split button + menu ============================ */
 .dlcv { position: relative; display: inline-block; }
-.dlcv__main { gap: 0.45rem; }
-.dlcv__caret { font-size: 0.7em; opacity: 0.85; }
+/* Split button: solid primary action + a divided caret for other formats. */
+.dlcv__split { display: inline-flex; }
+.dlcv__main {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.dlcv__toggle {
+  padding-inline: 0.7rem;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left-color: color-mix(in srgb, var(--accent-contrast) 35%, transparent);
+  margin-left: -1px;
+}
+.dlcv__caret { font-size: 0.8em; opacity: 0.9; }
 .dlcv__menu {
   position: absolute;
   top: calc(100% + 0.4rem);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1080,10 +1080,8 @@ main { display: block; }
 }
 .dlcv__caret { font-size: 0.8em; opacity: 0.9; }
 .dlcv__menu {
-  position: absolute;
-  top: calc(100% + 0.4rem);
-  right: 0;
-  z-index: 60;
+  position: fixed;
+  z-index: 200;
   min-width: 230px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Why

Feedback from Niina (on a large screen): pressing the blue **Download CV** button didn't seem to do anything — it only opened a dropdown whose items were easy to miss, and clicking the blue button should just give you the PDF.

A follow-up bug then surfaced: when opening the format menu via the caret, the menu was clipped — most of it rendered outside the hero panel and got cut off.

## What changed

**1. Split button — one click downloads the PDF** (`src/components/DownloadCV.tsx`, `src/styles/global.css`)
- The main blue button now downloads the polished "designed" CV immediately, with no intermediate menu step.
- A clearly divided caret segment (▾) remains as an explicit affordance for the **ATS-friendly** variant, separated by a subtle translucent seam that adapts to light/dark themes.

**2. Fix menu clipping** (`src/components/DownloadCV.tsx`, `src/styles/global.css`)
- The format menu lived inside the hero glass panel, which uses `overflow: hidden` (rounded corners, backdrop blur, the "Open to work" ribbon), so the absolutely-positioned menu was cut off below the panel edge.
- The menu now renders `position: fixed`, anchored to the button via `getBoundingClientRect()` and re-anchored on scroll/resize, so it escapes any ancestor clip context. Its `z-index` was raised to `200` to also sit above the sticky nav (`DownloadCV` renders in both the hero and the nav).

## Verification
- `bun run build` — succeeds
- `bunx tsc --noEmit` — clean

https://claude.ai/code/session_01WaKbj3Mq3mTjEcKfHbXSvP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaKbj3Mq3mTjEcKfHbXSvP)_