### PR TITLE
Add PR preview deploys (test branches before merging)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,17 +6,17 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Allow one concurrent deployment; cancel in-progress runs for newer pushes.
+# Serialize every write to the gh-pages branch (production + PR previews share
+# this group) so concurrent deploys can't race on the same branch. Don't cancel
+# an in-progress deploy — let it finish, then run the next.
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: gh-pages-deploy
+  cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,18 +33,13 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages (site root)
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          folder: dist
+          branch: gh-pages
+          clean: true
+          # Keep live PR previews intact when production redeploys.
+          clean-exclude: |
+            pr-preview
+            pr-preview/**

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,93 @@
+name: PR Preview
+
+# Publishes every pull request to a live URL so changes can be reviewed before
+# merging:  https://jackinf.github.io/pr-preview/pr-<number>/
+# The preview is rebuilt on each push and removed when the PR closes.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Share the gh-pages serialization group with the production deploy so writes to
+# the branch never race. Don't cancel in-progress runs (a half-pushed branch is
+# worse than a slightly stale preview).
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+
+      - name: Deploy preview to gh-pages/pr-preview/pr-${{ github.event.number }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          branch: gh-pages
+          target-folder: pr-preview/pr-${{ github.event.number }}
+          # clean is scoped to target-folder, so this only refreshes THIS
+          # preview — other previews and the production root are untouched.
+          clean: true
+          commit-message: "Deploy preview for PR #${{ github.event.number }}"
+
+      - name: Comment the preview URL (first time only)
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const n = context.issue.number;
+            const url = `https://jackinf.github.io/pr-preview/pr-${n}/`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: n,
+              body: [
+                `🚀 **Live preview:** ${url}`,
+                '',
+                'Rebuilt on every push to this PR, and removed automatically when it closes.',
+                '_First publish can take a minute to appear._',
+              ].join('\n'),
+            });
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Remove this PR's preview directory
+        run: |
+          set -e
+          dir="pr-preview/pr-${{ github.event.number }}"
+          if [ -d "$dir" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git rm -rf "$dir"
+            git commit -m "Remove preview for PR #${{ github.event.number }}"
+            git push
+          else
+            echo "No preview directory at $dir — nothing to clean up."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,19 @@ Bun may not be on PATH; if `bun` is not found, use `~/.bun/bin/bun` or
 5. **The legacy site is in `game/`** and is copied verbatim into `dist/game/` by the
    build. It uses relative asset paths — do not add root-absolute (`/...`) asset URLs
    there. It's a separate vanilla HTML/JS project (see `game/CLAUDE.md`).
-6. **User GitHub Pages site** serves from `/`, so asset URLs are root-relative and need
-   no base path.
+6. **Asset URLs must be document-relative, not root-absolute.** The same build is served
+   at `/` (production) and under `/pr-preview/pr-N/` (PR previews), so use `./favicon.svg`,
+   `game/`, `./assets/...` — never `/favicon.svg` or `/game/`. Bun already emits relative
+   `./assets/...`; keep new links relative too.
 
 ## Deploy
 
-Push to `master` → Actions builds and deploys `dist/`. Requires repo
-**Settings → Pages → Source = "GitHub Actions"** (one-time, manual).
+Push to `master` → `.github/workflows/deploy.yml` builds and publishes `dist/` to the
+**`gh-pages`** branch root (with `clean-exclude: pr-preview` so live previews survive).
+Requires repo **Settings → Pages → Source = "Deploy from a branch" → `gh-pages` → `/`**
+(one-time, manual).
+
+**PR previews:** `.github/workflows/preview.yml` deploys each PR to
+`gh-pages/pr-preview/pr-N/`, served at `https://jackinf.github.io/pr-preview/pr-N/`,
+rebuilt per push and cleaned up on close. `pull_request` workflows run from the **base**
+branch, so previews only apply to PRs opened after this lands on `master`.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ src/
 public/               # favicon.svg, cv.md
 scripts/              # build.ts, serve.ts
 game/                 # legacy 8-bit gamified résumé (served at /game/)
-.github/workflows/    # deploy.yml — Bun build + Pages deploy
+.github/workflows/    # deploy.yml (prod → gh-pages root) + preview.yml (PR previews)
 ```
 
 ## Editing content
@@ -101,11 +101,30 @@ sync when you change `cv.ts`.
 ## Deployment
 
 Pushes to `master` trigger `.github/workflows/deploy.yml`, which builds with Bun and
-publishes `dist/` to GitHub Pages.
+publishes `dist/` to the **`gh-pages`** branch root (preserving any live PR previews
+under `pr-preview/`).
 
 > **One-time setup:** In the GitHub repo, go to **Settings → Pages → Build and
-> deployment → Source** and select **"GitHub Actions"**. (Previously this repo served
-> from the branch root; the Actions workflow replaces that.)
+> deployment → Source** and select **"Deploy from a branch"**, then choose the
+> **`gh-pages`** branch and **`/ (root)`** folder. This single Pages source serves both
+> production (`/`) and PR previews (`/pr-preview/pr-N/`).
+
+### PR previews
+
+Every pull request is published to a live URL so changes can be reviewed before merging:
+
+```
+https://jackinf.github.io/pr-preview/pr-<number>/
+```
+
+`.github/workflows/preview.yml` builds the PR and deploys it to `gh-pages` under
+`pr-preview/pr-<number>/`, posts the link as a comment, rebuilds on each push, and
+removes the directory when the PR closes. Production redeploys never wipe active
+previews (`clean-exclude`), and all asset paths are relative so the same build works
+at the root and under a preview subpath.
+
+> Because `pull_request` workflows run from the version on the **base** branch, previews
+> activate for PRs opened **after** this workflow lands on `master`.
 
 ## Legacy site
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -53,7 +53,9 @@ let out = html.replace(
 );
 out = out.replace(
   "</head>",
-  '  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />\n  </head>',
+  // Relative href (not "/favicon.svg") so the build works both at the site
+  // root AND under a subpath (e.g. PR previews at /pr-preview/pr-N/).
+  '  <link rel="icon" href="./favicon.svg" type="image/svg+xml" />\n  </head>',
 );
 if (out !== html) {
   await writeFile(htmlPath, out);
@@ -69,5 +71,10 @@ if (existsSync(`${root}public`)) {
 
 console.log("→ Copying game/ → dist/game/");
 await cp(`${root}game`, `${dist}/game`, { recursive: true });
+
+// GitHub Pages serves the deploy branch (gh-pages) through Jekyll by default,
+// which skips files/dirs beginning with "_". A .nojekyll file disables that so
+// hashed asset names are served verbatim.
+await writeFile(`${dist}/.nojekyll`, "");
 
 console.log("✓ Build complete → dist/");

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,7 +8,7 @@ export function Footer() {
         <div className="footer__meta">
           © 2026 {profile.name} · Built with Bun &amp; React
           <br />
-          <a className="footer__game" href="/game/">
+          <a className="footer__game" href="game/">
             Try the 8-bit résumé version
             <ArrowIcon className="icon arrow" />
           </a>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -30,7 +30,7 @@ export function Nav({ theme, onToggleTheme }: Props) {
           <a className="nav__link" href="#languages">Languages</a>
           <a className="nav__link" href="#projects">Projects</a>
           <a className="nav__link" href="#skills">Skills</a>
-          <a className="nav__link nav__game" href="/game/" title="The gamified version">
+          <a className="nav__link nav__game" href="game/" title="The gamified version">
             ▶ Game
           </a>
           <DownloadCV />

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -491,7 +491,8 @@ export const projects: Project[] = [
     description:
       "This site (Bun + React 19) plus a sidescroller game that tells the same story — built and maintained with AI coding agents.",
     tags: ["React", "Bun", "TypeScript", "Canvas"],
-    url: "/game/",
+    // Relative (not "/game/") so it resolves under PR-preview subpaths too.
+    url: "game/",
   },
 ];
 


### PR DESCRIPTION
Introduces a gitflow that publishes **every PR to a live URL** so you can test before merging:

```
https://jackinf.github.io/pr-preview/pr-<number>/
```

## How it works
- **`deploy.yml` (production)** now publishes `dist/` to the **`gh-pages`** branch root instead of via the Actions Pages artifact. `clean-exclude: pr-preview` keeps live previews intact across production redeploys.
- **`preview.yml` (new)** builds each PR and deploys it to `gh-pages/pr-preview/pr-<number>/`, comments the link on the PR, rebuilds on every push, and removes the directory when the PR closes.
- Both workflows share a `concurrency` group so writes to `gh-pages` never race.

## Supporting changes
- **Relative asset URLs** so one build works at both `/` and `/pr-preview/pr-N/`: favicon → `./favicon.svg`, game links in `Nav`/`Footer`/`cv.ts` → `game/`. (Bun already emits relative `./assets/...`.)
- **`build.ts` emits `.nojekyll`** — branch-served Pages runs Jekyll by default, which would skip hashed assets.
- **Docs** (`README.md`, `CLAUDE.md`) updated for the new model.

## ⚠️ One-time manual step (required)
After merging, change the Pages source:
**Settings → Pages → Build and deployment → Source → "Deploy from a branch" → `gh-pages` → `/ (root)`.**

Until then, the `gh-pages` branch will be built but not served.

## Notes / limitations
- `pull_request` workflows run from the version on the **base** branch, so previews only activate for PRs opened **after** this lands on `master` — this PR itself won't get a preview.
- First production push creates the `gh-pages` branch.

## Verification
- `bun run build` — succeeds; confirmed `./favicon.svg`, `.nojekyll`, and no remaining absolute `/game/` references in the bundle.
- `bunx tsc --noEmit` — clean.
- Both workflow YAML files parse.

https://claude.ai/code/session_01WaKbj3Mq3mTjEcKfHbXSvP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaKbj3Mq3mTjEcKfHbXSvP)_